### PR TITLE
Fix all five open code bugs and add a name verifier

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -3,10 +3,10 @@
 ```yaml
 project: Deadwire
 description: PZ mod — perimeter trip lines and electric fencing for Project Zomboid (B42+)
-last_session: 16
+last_session: 17
 last_updated: 2026-08-05
-continue_with: "Fix #17 and #18 (one-liners, revives the whole camouflage system), then #14/#15/#16, then finish the in-game smoke test"
-blockers: "World sprite ART is placeholder. The deadwire_01 tilesheet ships and is declared in mod.info, so sprites should load, but the 8 images are Session 10 placeholders, not the finished Gemini art. Whether they render at all is still unverified in-game."
+continue_with: "In-game smoke test: sprites load, recipes registered, loot reachable, sounds play, camo now visible/degrading. All five code bugs (#14-#18) are fixed and merged."
+blockers: "World sprite ART is placeholder. The deadwire_01 tilesheet ships, is declared in mod.info, and its 8 tile indices now provably match the names Config.Sprites asks for (verify_names.py checks this), so the sprites should load and the construction_01_24 fallback should never fire. The 8 images themselves are still Session 10 placeholders, not the finished Gemini art, and nothing has been confirmed rendering in-game."
 
 tech:
   stack: pz-lua-mod
@@ -42,13 +42,54 @@ workflow:
 7. **Detection is CLIENT-side**: OnZombieUpdate/OnPlayerUpdate are client events
 8. **No guards around unverified API names.** A guard around a typo is indistinguishable from a guard around a real fallback: it turns a loud error into a silently absent feature. This cost three dead features, found in Session 16.
 
-## Verified against the installed 42.20 jar (Session 16)
+## Name verification: run the script, do not check by hand
 
-Confirmed to EXIST: `setStaggerBack`, `knockDown`, `setAlphaAndTarget`, `getWorldSoundManager`, `PlayWorldSound`, `IsoObject:setOutlineHighlight`, `setOutlineHighlightCol`, `isAdmin`, `BodyPartType.Foot_L`, `IsoThumpable`, `ISBuildingObject`, `ProceduralDistributions`, `IsoGridSquare:isGeneratorPoweringSquare`.
+```bash
+python scripts/verify_names.py          # exit 0 = every name resolves
+```
 
-Confirmed NOT to exist: `Perks.Foraging` (it is `PlantScavenging`), `Perks.Carpentry` (it is `Woodwork`), `Capability.CanBuildAnywhere` (nearest real: `UseBuildCheat`), the `Climate` global (it is `getClimateManager()`), `getRainStrength` (it is `getRainIntensity`), `Base.TreeBranch` (it is `TreeBranch2`). There is **no electrocution system anywhere in the jar**.
+`scripts/verify_names.py` resolves every game name the mod references against the
+installed 42.20 install: `Perks.X`, `Capability.X`, `BodyPartType.X`, `Base.X` item
+ids in both Lua and scripts, `ProceduralDistributions` names, recipe
+`SkillRequired`/`xpAward` perks, `Icon =` PNG existence, sprite names against the
+mod's own tilesheet, and root-vs-42 `mod.info` agreement. 67 references at present.
+`scripts/pzclass.py` is the Java `.class` reader underneath it.
 
-Technique: parse the constant pool of each `.class` in `projectzomboid.jar` — zip read, walk the pool, take tag-1 UTF8 entries. ~142k identifiers in seconds. Do NOT substring-match against the vanilla Lua tree: that passes `Perks.Foraging` as valid because the word appears elsewhere.
+**This exists because checking by hand does not hold.** Session 16 found six name
+bugs manually and wrote the technique into this file without committing a tool. The
+very next name written by hand — `ChurchMisc` → `ChurchStorageMisc` — was also wrong
+and was committed described as "verified against vanilla ProceduralDistributions.lua
+on 42.20". Session 17 found it in seconds with the script. A checked claim that
+leaves no artifact decays into an unchecked one.
+
+Read declared **fields and methods**, not the raw constant pool. A constant-pool
+grep matches any string anywhere in the class, so it passes `Perks.Foraging`.
+Note also that `Perks` is not a Java enum: it is a holder class of
+`public static final` fields, so an ACC_ENUM-only check finds nothing there.
+
+Confirmed to EXIST: `setStaggerBack`, `knockDown`, `setAlphaAndTarget`,
+`getWorldSoundManager`, `PlayWorldSound`, `IsoObject:setOutlineHighlight`,
+`setOutlineHighlightCol`, `isAdmin`, `BodyPartType.Foot_L`, `IsoThumpable`,
+`ISBuildingObject`, `ProceduralDistributions`, `IsoGridSquare:isGeneratorPoweringSquare`,
+`getClimateManager():getRainIntensity()`, `Capability.UseBuildCheat`,
+`IsoPlayer:getRole()`, `Role:hasCapability`, `ItemContainer:getFirstTypeRecurse`.
+
+Confirmed NOT to exist: `Perks.Foraging` (it is `PlantScavenging`), `Perks.Carpentry`
+(it is `Woodwork`), `Capability.CanBuildAnywhere` (it is `UseBuildCheat`), the
+`Climate` global (it is `getClimateManager()`), `getRainStrength` (it is
+`getRainIntensity`), `Base.TreeBranch` (it is `TreeBranch2`), `ChurchMisc` /
+`ChurchStorageMisc` (**42.20 has no church distribution at all**). There is **no
+electrocution system anywhere in the jar**.
+
+**Internal name ≠ displayed name.** `Woodwork` displays as "Carpentry" and
+`PlantScavenging` displays as "Foraging" (`IGUI_perks_*` / `Sandbox_*` in the vanilla
+EN translations). Mod code must use the internal name; player-facing tooltips must
+use the displayed one. The Sandbox_EN tooltips saying "Carpentry 2" and "Foraging"
+are therefore correct and were deliberately left alone.
+
+Rain intensity is normalised 0.0-1.0: vanilla `forageSystem` rounds
+`getPrecipitationIntensity()` to one decimal and multiplies chances by it, and
+`Bobber.lua` tests `getFogIntensity() >= 0.4`. `STORM_THRESHOLD = 0.8` relies on this.
 
 ## Architecture
 
@@ -60,12 +101,45 @@ Shared (WireNetwork, Config) → Client (Detection, UI, TriggerHandlers, CamoVis
 
 | Phase | Content | Status |
 |-------|---------|--------|
-| 1 (MVP) | Tier 0 + Tier 1 + Camouflage + SandboxVars | Code complete, 5 open bugs, sprites incomplete |
+| 1 (MVP) | Tier 0 + Tier 1 + Camouflage + SandboxVars | Code complete, no open bugs, untested in-game, sprite art placeholder |
 | 2 | Pull-alarms | Not started |
 | 3 | Electric fencing | Issue #13, API researched |
 | 4 | Advanced | Not started |
 
 ## Recent Changes
+
+### Session 17 (2026-08-05): every open code bug fixed, plus a name verifier
+
+Built `scripts/verify_names.py` + `scripts/pzclass.py` first, then fixed what it
+found. 67 references now resolve; 143/143 tests pass (was 131).
+
+Closed #14 through #18:
+
+- **#17** `Perks.Foraging` → `Perks.PlantScavenging`. Camouflaged wires were
+  invisible to every player forever, because the nil perk made `getPerkLevel`
+  return 0 for everyone.
+- **#18** the whole Climate call was fiction (`Climate.GetInstance():getRainStrength()`
+  — no such global, no such method). Now `getClimateManager():getRainIntensity()`.
+  Camouflage had never degraded from weather.
+- **#14** `Capability.CanBuildAnywhere` → `UseBuildCheat`, in all **three** places
+  (the issue named one), plus a nil guard on `getRole()`, which threw in SP.
+- **#15** two MP exploits closed: `WireTriggered` now requires the reporter to be
+  within 3 tiles and on the same floor, and `PlaceWire` verifies and consumes the
+  kit server-side instead of trusting the client.
+- **#16** cooldowns moved from game time to real seconds. Also fixed a bug the issue
+  did not mention: the server set the cooldown while detection checks it on the
+  *client*, so in MP the cooldown never applied at all. `WireTriggered` now
+  broadcasts the duration (not an absolute time — clock skew) and clients mirror it.
+  The broadcast is no longer gated on `soundName`, so silent Tanglefoot gets one too;
+  the client no longer substitutes a default sound when `soundName` is absent, which
+  would have made Tanglefoot audible.
+
+Two bugs found that were not on any issue: `ChurchStorageMisc` did not exist (bells
+silently absent from that table) and both Tier 1 recipes required `Carpentry`, which
+is not a perk — `Woodwork` is. Recipes were likely uncraftable.
+
+Unverified in-game still: sprites render, recipes register, loot reachable, sounds
+play. Nothing here was tested against a running game.
 
 ### Session 16 (2026-08-05): B42.20.2 audit — six silent failures, three fixed
 
@@ -90,33 +164,36 @@ Built `pz_unpack.py` at `c:/xampp/htdocs/pz-tilesheet/`. Generated all 4 invento
 ## To Resume
 
 ```
-Deadwire v0.1.1, Session 17. Phase 1 code complete but NOT shippable.
+Deadwire v0.1.1, Session 18. Phase 1 code complete, ZERO open code bugs,
+but nothing has ever been confirmed working in a running game.
 
-THIS WINDOW, in order:
+Everything left needs PZ actually running. That is the whole remaining list.
 
-1. #17: CamoVisibility.lua:73, Perks.Foraging -> Perks.PlantScavenging. One word.
-2. #18: CamoDegradation.lua:22, replace getRainStrength's body with
-     local cm = getClimateManager()
-     if not cm then return 0 end
-     return cm:getRainIntensity() or 0
-   Confirm in-game whether getRainIntensity is normalised 0-1; STORM_THRESHOLD=0.8 assumes it.
-3. #14: ServerCommands.lua:126, Capability.CanBuildAnywhere -> Capability.UseBuildCheat,
-   and nil-guard getRole().
-4. #16: cooldown is written in seconds but measured in game time, so 36 "seconds" is about
-   1.5 real seconds. Decide real-time (preferred) vs renaming the field.
-5. #15: PlaceWire never checks the player holds a kit, and WireTriggered accepts any client's
-   claim for any coordinate. Both MP-only exploits.
-6. Finish the smoke test. Harness works: PZ running with PZ Test Pilot enabled, then
+THIS WINDOW:
+
+1. Smoke test. Harness: PZ running with PZ Test Pilot enabled, then
      cd c:/xampp/htdocs/pz-test-pilot
      python scripts/cmd.py run_lua 'code=<lua>'
    cmd.py splits params on '=', so the code MUST be passed as code=<lua>.
-   Still unverified: sprites load, recipes registered, loot tables reachable, sounds play.
+   Check, in order:
+     a. getSprite("deadwire_01_0") .. _7 all non-nil  -> tilesheet actually loaded
+     b. getScriptManager():getItem("Base.Deadwire_TinCanTripLineKit") non-nil
+     c. all four craftRecipes registered (Woodwork:2 now, was the bogus Carpentry:2)
+     d. ProceduralDistributions.list.JanitorMisc contains Base.Bell after world load
+     e. place a wire, walk a zombie into it, hear the sound
+     f. camouflage a wire, check a low-skill character cannot see it and a
+        PlantScavenging 7 character can -- this path has NEVER worked before now
+     g. confirm getRainIntensity() really is 0-1 in a live storm (STORM_THRESHOLD=0.8)
 
-THEN the blocker: world sprite ART. The deadwire_01 tilesheet ships (.pack + .tiles, both
-declared in mod.info) so the sprites should load and the construction_01_24 fallback should
-never fire — but that is UNVERIFIED, and the 8 images in it are Session 10 placeholders.
-Source PNGs at repo root need crop/resize to 64x128 and a tilesheet rebuild.
-Check which is true first: getSprite("deadwire_01_0") through _7 via the harness.
+2. Then the blocker: world sprite ART. The 8 images in deadwire_01 are Session 10
+   placeholders. Source PNGs at repo root need crop/resize to 64x128 and a
+   tilesheet rebuild. Step 1a tells you whether the sheet loads at all before you
+   spend time on art.
 
-Run tests anytime: run_tests.bat
+3. Parked for Rob: delete the stale repo-root mod.info (0.1.0, poster=poster.png).
+   It sits outside Contents/ so PZ never reads it, but it reads like the manifest
+   and is not one. Session 17 misread it as such.
+
+Before any commit that touches names:  python scripts/verify_names.py
+Run tests anytime:                     run_tests.bat   (143 tests)
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ scratch/
 
 # Source assets (not part of mod)
 assets-testing/
+
+# Python tooling
+__pycache__/
+*.pyc
+
+# AFK session log (working notes, not project history)
+.claude/afk-log.md

--- a/Contents/mods/Deadwire/42/media/lua/client/Deadwire/CamoVisibility.lua
+++ b/Contents/mods/Deadwire/42/media/lua/client/Deadwire/CamoVisibility.lua
@@ -1,18 +1,20 @@
 -- Deadwire CamoVisibility: Per-client alpha control for camouflaged wires
--- Client: checks local player's Foraging level and updates IsoThumpable alpha.
+-- Client: checks the local player's scavenging level and updates IsoThumpable alpha.
 --
 -- Runs on OnTick with a 60-tick throttle (~1s at 60fps).
 -- Visual-only: server state is unchanged. Each client sees wires at a
--- different alpha based on their own Foraging skill level + distance.
+-- different alpha based on their own skill level + distance.
+--
+-- The skill is PlantScavenging (shown in-game as "Foraging"). Perks.Foraging
+-- is NOT a real enum member: reading it yields nil, getPerkLevel(nil) returns
+-- 0, and every player is permanently at level 0, so camouflaged wires were
+-- invisible to absolutely everyone. Verified against 42.20 (Issue #17).
 --
 -- Detection scaling (all thresholds configurable via SandboxVars):
---   Foraging 0-2  → alpha 0.0  (invisible — trips it blind)
---   Foraging 3-4  → alpha 0.15 (faint shimmer, close range only)
---   Foraging 5-6  → alpha 0.4  (semi-visible, moderate range)
---   Foraging 7+   → alpha 0.8  (clear + orange outline)
---
--- NOTE: Perks.Foraging — verify enum name in-game.
--- NOTE: setOutlineHighlight/setOutlineHighlightCol — verify API in-game.
+--   level 0-2  → alpha 0.0  (invisible — trips it blind)
+--   level 3-4  → alpha 0.15 (faint shimmer, close range only)
+--   level 5-6  → alpha 0.4  (semi-visible, moderate range)
+--   level 7+   → alpha 0.8  (clear + orange outline)
 
 require "Deadwire/Config"
 require "Deadwire/WireNetwork"
@@ -24,7 +26,7 @@ local tickCounter   = 0
 -- Compute alpha + outline flag for a single wire
 -----------------------------------------------------------
 
-local function getVisibility(foragingLevel, dist, isOwner, adminBypass)
+local function getVisibility(skillLevel, dist, isOwner, adminBypass)
     -- Owner always sees their own wires (configurable)
     if isOwner and DeadwireConfig.getSandbox("CamoVisibleToOwner", true) then
         return 1.0, false
@@ -35,7 +37,7 @@ local function getVisibility(foragingLevel, dist, isOwner, adminBypass)
         return 1.0, false
     end
 
-    -- Foraging-based visibility (thresholds + detection ranges)
+    -- Skill-based visibility (thresholds + detection ranges)
     local fullLevel = DeadwireConfig.getSandbox("CamoDetectLevelFull", 7)
     local midLevel  = DeadwireConfig.getSandbox("CamoDetectLevelMid",  5)
     local lowLevel  = DeadwireConfig.getSandbox("CamoDetectLevelLow",  3)
@@ -43,13 +45,13 @@ local function getVisibility(foragingLevel, dist, isOwner, adminBypass)
     local midRange  = DeadwireConfig.getSandbox("CamoDetectRangeMid",   8)
     local lowRange  = DeadwireConfig.getSandbox("CamoDetectRangeLow",   3)
 
-    if foragingLevel >= fullLevel and dist <= fullRange then
+    if skillLevel >= fullLevel and dist <= fullRange then
         return 0.8, true   -- clear + orange outline
     end
-    if foragingLevel >= midLevel and dist <= midRange then
+    if skillLevel >= midLevel and dist <= midRange then
         return 0.4, false  -- semi-visible
     end
-    if foragingLevel >= lowLevel and dist <= lowRange then
+    if skillLevel >= lowLevel and dist <= lowRange then
         return 0.15, false -- faint shimmer
     end
     return 0.0, false      -- invisible
@@ -69,10 +71,9 @@ local function onTick()
     local player = getPlayer()
     if not player then return end
 
-    local username     = player:getUsername() or ""
-    local foragingLevel = player:getPerkLevel(Perks.Foraging)
-    -- isAdmin() is a global client function confirmed for B42
-    local adminBypass  = isAdmin and isAdmin() or false
+    local username   = player:getUsername() or ""
+    local skillLevel = player:getPerkLevel(Perks.PlantScavenging)
+    local adminBypass = isAdmin() or false
 
     local px = math.floor(player:getX())
     local py = math.floor(player:getY())
@@ -91,7 +92,7 @@ local function onTick()
                     local dist     = math.sqrt(dx * dx + dy * dy)
                     local isOwner  = (wire.ownerId == username)
                     local alpha, outline = getVisibility(
-                        foragingLevel, dist, isOwner, adminBypass)
+                        skillLevel, dist, isOwner, adminBypass)
 
                     obj:setAlphaAndTarget(alpha)
                     if outline then

--- a/Contents/mods/Deadwire/42/media/lua/client/Deadwire/EventHandlers.lua
+++ b/Contents/mods/Deadwire/42/media/lua/client/Deadwire/EventHandlers.lua
@@ -38,18 +38,30 @@ local function onServerCommand(module, command, args)
 end
 
 -----------------------------------------------------------
--- WireTriggered: Play sound effect at wire location
+-- WireTriggered: Play sound effect and apply the server's cooldown
+--
+-- Detection (Detection.lua) checks isOnCooldown against this client's own
+-- WireNetwork copy, so the server's cooldown has to be mirrored here or the
+-- wire re-arms immediately on every client in MP.
 -----------------------------------------------------------
 
 handlers["WireTriggered"] = function(args)
+    if not hasPosition(args) then return end
+
+    if args.cooldownSeconds then
+        DeadwireNetwork.setCooldown(args.x, args.y, args.z, args.cooldownSeconds)
+    end
+
+    -- No soundName means a silent trap (tanglefoot). Do not substitute one:
+    -- the previous default of TIN_CAN_RATTLE would have made it audible.
+    if not args.soundName then return end
+
     local sq = getSquareFromArgs(args)
     if not sq then return end
 
-    local soundName = args.soundName or DeadwireConfig.Sounds.TIN_CAN_RATTLE
     local audioRadius = args.audioRadius or 15
-
-    getSoundManager():PlayWorldSound(soundName, sq, 0, audioRadius, 1.0, false)
-    DeadwireConfig.debugLog("Sound: " .. soundName .. " at " .. args.x .. "," .. args.y .. "," .. args.z)
+    getSoundManager():PlayWorldSound(args.soundName, sq, 0, audioRadius, 1.0, false)
+    DeadwireConfig.debugLog("Sound: " .. args.soundName .. " at " .. args.x .. "," .. args.y .. "," .. args.z)
 end
 
 -----------------------------------------------------------

--- a/Contents/mods/Deadwire/42/media/lua/server/Deadwire/CamoDegradation.lua
+++ b/Contents/mods/Deadwire/42/media/lua/server/Deadwire/CamoDegradation.lua
@@ -5,30 +5,33 @@
 -- ServerCommands.lua WireTriggered handler — not here.
 --
 -- Degradation model:
---   - Rain strength 0.0-0.8: degrade = floor(baseRate * rainStrength)
---   - Rain strength 0.8+:    degrade = floor(baseRate * stormMult)
+--   - Rain intensity 0.0-0.8: degrade = floor(baseRate * rainIntensity)
+--   - Rain intensity 0.8+:    degrade = floor(baseRate * stormMult)
 --   - When durability hits 0: camo removed, WireCamouflaged broadcast to all clients
 --
--- NOTE: Climate.GetInstance():getRainStrength() — verify API name in-game.
---       Alternative: getWorld():getWeather():getRainStrength()
+-- The old implementation called Climate.GetInstance():getRainStrength(). No part
+-- of that exists in 42.20: there is no `Climate` global, and no getRainStrength
+-- on anything. Both guards failed silently and the function always returned 0, so
+-- camouflage never degraded from weather at all. Verified against 42.20 (Issue #18).
+--
+-- The real API is getClimateManager():getRainIntensity(), returning a float.
+-- Range is 0.0-1.0: ClimateManager's sibling intensity getters are used that way
+-- throughout vanilla (forageSystem rounds getPrecipitationIntensity() to one
+-- decimal and multiplies chances by it; Bobber.lua tests getFogIntensity() >= 0.4),
+-- which is what STORM_THRESHOLD below assumes.
+-- getPrecipitationIntensity() is the near-equivalent that also counts snow.
 
 require "Deadwire/Config"
 require "Deadwire/WireNetwork"
 
 -----------------------------------------------------------
--- Get current rain strength (0.0 = dry, 1.0+ = heavy rain)
+-- Get current rain intensity (0.0 = dry, 1.0 = heaviest)
 -----------------------------------------------------------
 
-local function getRainStrength()
-    -- Try Climate API (primary B42 weather system)
-    if Climate and Climate.GetInstance then
-        local climate = Climate.GetInstance()
-        if climate and climate.getRainStrength then
-            return climate:getRainStrength() or 0
-        end
-    end
-    -- Fallback: not raining if API unavailable
-    return 0
+local function getRainIntensity()
+    local climate = getClimateManager()
+    if not climate then return 0 end
+    return climate:getRainIntensity() or 0
 end
 
 -----------------------------------------------------------
@@ -38,18 +41,18 @@ end
 local function onEveryTenMinutes()
     if not DeadwireConfig.getSandbox("EnableCamouflage", true) then return end
 
-    local rainStrength = getRainStrength()
-    if rainStrength <= 0 then return end
+    local rainIntensity = getRainIntensity()
+    if rainIntensity <= 0 then return end
 
     local baseRate    = DeadwireConfig.getSandbox("CamoRainDegradeRate",  5)
     local stormMult   = DeadwireConfig.getSandbox("CamoStormMultiplier",  2.0)
     local STORM_THRESHOLD = 0.8
 
     local effective
-    if rainStrength >= STORM_THRESHOLD then
+    if rainIntensity >= STORM_THRESHOLD then
         effective = math.floor(baseRate * stormMult)
     else
-        effective = math.floor(baseRate * rainStrength)
+        effective = math.floor(baseRate * rainIntensity)
     end
 
     if effective <= 0 then return end
@@ -82,7 +85,7 @@ local function onEveryTenMinutes()
 
     if #toRemove > 0 then
         DeadwireConfig.log("CamoDegradation: " .. #toRemove
-            .. " wire(s) lost camouflage from rain (strength=" .. rainStrength .. ")")
+            .. " wire(s) lost camouflage from rain (intensity=" .. rainIntensity .. ")")
     end
 end
 

--- a/Contents/mods/Deadwire/42/media/lua/server/Deadwire/LootDistribution.lua
+++ b/Contents/mods/Deadwire/42/media/lua/server/Deadwire/LootDistribution.lua
@@ -10,14 +10,41 @@ local function getSpawnChance()
     return chances[rate] or 12
 end
 
+-- Append `item` at `chance` to each named distribution, returning how many
+-- took it.
+--
+-- A missing name is logged loudly rather than skipped in silence. Every bug
+-- this file has had was a name that resolved to nil and produced an absent
+-- feature with a clean log; a warning here is what makes the next one visible
+-- the first time the world generates.
+local function addToDistributions(distNames, item, chance)
+    local count = 0
+    for _, distName in ipairs(distNames) do
+        local dist = ProceduralDistributions.list[distName]
+        if dist and dist.items then
+            table.insert(dist.items, item)
+            table.insert(dist.items, chance)
+            count = count + 1
+        else
+            DeadwireConfig.log("LootDistribution: WARNING no distribution '"
+                .. distName .. "' -- " .. item .. " will not spawn there")
+        end
+    end
+    return count
+end
+
 local function preDistributionMerge()
     if not isServer() then return end
     if not DeadwireConfig.getSandbox("EnableMod", true) then return end
 
     local chance = getSpawnChance()
 
-    -- Bell loot: general utility/farm locations
-    -- Names verified against vanilla ProceduralDistributions.lua on 42.20
+    -- Bell loot: general utility/farm locations.
+    -- ChurchStorageMisc used to be in this list and does not exist -- 42.20 has
+    -- no church distribution at all. It was added as a "verified" replacement
+    -- for the equally nonexistent ChurchMisc and silently spawned nothing.
+    -- Every name below is checked by scripts/verify_names.py against the
+    -- installed game; run that rather than adding a name by eye.
     local bellDists = {
         "FarmerTools",
         "BarnTools",
@@ -25,20 +52,10 @@ local function preDistributionMerge()
         "GardenStoreTools",
         "SchoolLockers",
         "OfficeDeskHome",
-        "ChurchStorageMisc",
+        "JanitorMisc",
     }
 
-    local bellCount = 0
-    for _, distName in ipairs(bellDists) do
-        if ProceduralDistributions.list[distName] then
-            table.insert(ProceduralDistributions.list[distName].items, "Base.Bell")
-            table.insert(ProceduralDistributions.list[distName].items, chance)
-            bellCount = bellCount + 1
-        end
-    end
-
     -- Issue #12: ReinforcedTripLineKit in metalworking locations
-    -- Names verified against vanilla ProceduralDistributions.lua on 42.20
     local kitDists = {
         "MetalShopTools",
         "MetalWorkerTools",
@@ -46,14 +63,9 @@ local function preDistributionMerge()
         "GarageMetalwork",
     }
 
-    local kitCount = 0
-    for _, distName in ipairs(kitDists) do
-        if ProceduralDistributions.list[distName] then
-            table.insert(ProceduralDistributions.list[distName].items, "Base.Deadwire_ReinforcedTripLineKit")
-            table.insert(ProceduralDistributions.list[distName].items, chance)
-            kitCount = kitCount + 1
-        end
-    end
+    local bellCount = addToDistributions(bellDists, "Base.Bell", chance)
+    local kitCount  = addToDistributions(kitDists,
+        "Base.Deadwire_ReinforcedTripLineKit", chance)
 
     DeadwireConfig.log("LootDistribution: bells→" .. bellCount .. " tables, kits→" .. kitCount .. " tables (chance=" .. chance .. ")")
 end

--- a/Contents/mods/Deadwire/42/media/lua/server/Deadwire/ServerCommands.lua
+++ b/Contents/mods/Deadwire/42/media/lua/server/Deadwire/ServerCommands.lua
@@ -13,9 +13,38 @@ DeadwireServerCommands = DeadwireServerCommands or {}
 -- Command handler table
 local handlers = {}
 
+-- How close the reporting player must be to a wire for the server to believe
+-- their WireTriggered report. Detection is client-side by necessity
+-- (OnZombieUpdate is a client event), so the claim cannot be eliminated --
+-- only bounded to wires the reporter could plausibly see. Fixes #15.
+local TRIGGER_MAX_DIST = 3
+
 -- DRY: validate args contain position fields
 local function hasPosition(args)
     return args and args.x and args.y and args.z
+end
+
+-- Admin/privileged check.
+-- Capability.CanBuildAnywhere does not exist in 42.20; indexing the enum
+-- yielded nil, hasCapability(nil) returned false, and admins were silently
+-- denied. The real capability is UseBuildCheat. getRole() can also return nil
+-- (single player, or a player with no role assigned), which threw. Fixes #14.
+local function isPrivileged(player)
+    if not player then return false end
+    local role = player:getRole()
+    if not role then return false end
+    return role:hasCapability(Capability.UseBuildCheat)
+end
+
+-- Does this player actually hold the kit this wire type costs?
+-- The client-side build action consumes a kit, but PlaceWire is a separate
+-- server command any client can send directly, so it must check for itself.
+local function findKit(player, wireType)
+    local kitItem = DeadwireConfig.KitItems[wireType]
+    if not kitItem then return nil, true end   -- type needs no kit
+    local inv = player:getInventory()
+    if not inv then return nil, false end
+    return inv:getFirstTypeRecurse(kitItem), false
 end
 
 -----------------------------------------------------------
@@ -82,12 +111,25 @@ handlers["PlaceWire"] = function(player, args)
         return
     end
 
+    -- Player must actually hold the kit. Without this a modified client can
+    -- place wires it never crafted, bounded only by WireMaxPerPlayer. Fixes #15.
+    local kitItemObj, kitless = findKit(player, wireType)
+    if not kitless and not kitItemObj then
+        DeadwireConfig.log("PlaceWire: " .. username .. " has no kit for " .. wireType)
+        return
+    end
+
     -- Create IsoThumpable + register in WireNetwork + persist
     local networkId = DeadwireNetwork.generateNetworkId()
     local obj = DeadwireWireManager.createWire(sq, wireType, username, networkId, args.north)
     if not obj then
         DeadwireConfig.log("PlaceWire: WireManager.createWire failed")
         return
+    end
+
+    -- Consume only after placement is confirmed
+    if kitItemObj then
+        player:getInventory():Remove(kitItemObj)
     end
 
     if DeadwireConfig.getSandbox("LogWirePlacements", true) then
@@ -123,7 +165,7 @@ handlers["RemoveWire"] = function(player, args)
 
     -- Only owner or admin can remove
     local username = player:getUsername() or "SP"
-    if wire.ownerId ~= username and not player:getRole():hasCapability(Capability.CanBuildAnywhere) then
+    if wire.ownerId ~= username and not isPrivileged(player) then
         DeadwireConfig.log("RemoveWire: " .. username .. " not authorized")
         return
     end
@@ -147,6 +189,19 @@ end
 handlers["WireTriggered"] = function(player, args)
     if not hasPosition(args) or not args.wireType then return end
 
+    -- The reporter must be standing near the wire they claim fired. Without
+    -- this any client can destroy every single-use wire on the map, and burn
+    -- every camouflage layer, by reporting arbitrary coordinates. Fixes #15.
+    local psq = player:getSquare()
+    if not psq
+        or psq:getZ() ~= args.z
+        or math.abs(psq:getX() - args.x) > TRIGGER_MAX_DIST
+        or math.abs(psq:getY() - args.y) > TRIGGER_MAX_DIST then
+        DeadwireConfig.debugLog("WireTriggered: rejected distant report from "
+            .. (player:getUsername() or "SP"))
+        return
+    end
+
     local wire = DeadwireNetwork.getTile(args.x, args.y, args.z)
     if not wire then return end
 
@@ -166,6 +221,7 @@ handlers["WireTriggered"] = function(player, args)
     soundRadius = math.floor(soundRadius * multiplier)
 
     -- State changes based on wire type
+    local cooldownSeconds = nil
     if defaults.breakOnTrigger then
         -- Single-use: destroy wire
         DeadwireWireManager.destroyWire(args.x, args.y, args.z)
@@ -175,10 +231,9 @@ handlers["WireTriggered"] = function(player, args)
             z = args.z,
         })
     else
-        -- Reusable: set cooldown
+        -- Reusable: set cooldown. cooldownSeconds is real seconds (#16).
         local cooldownSec = defaults.cooldownSeconds or 36
-        local cooldownHours = cooldownSec / 3600
-        DeadwireNetwork.setCooldown(args.x, args.y, args.z, cooldownHours)
+        cooldownSeconds = DeadwireNetwork.setCooldown(args.x, args.y, args.z, cooldownSec)
     end
 
     -- Degrade camo durability if camouflaged
@@ -203,14 +258,20 @@ handlers["WireTriggered"] = function(player, args)
             .. args.x .. "," .. args.y .. "," .. args.z .. " by " .. username)
     end
 
-    -- Broadcast to all clients for MP sound (detecting client already played locally)
-    if soundName then
+    -- Broadcast to all clients: sound for MP audio, cooldownSeconds so their
+    -- local WireNetwork agrees the wire is spent. Detection runs client-side
+    -- against the client's own copy, so without this the cooldown existed only
+    -- on the server and every reusable wire re-armed instantly for every client
+    -- in MP. Tanglefoot has no sound and still needs the cooldown, so the
+    -- broadcast is no longer conditional on soundName.
+    if soundName or cooldownSeconds then
         sendServerCommand(DeadwireConfig.MODULE, "WireTriggered", {
             x = args.x,
             y = args.y,
             z = args.z,
             soundName = soundName,
             audioRadius = soundRadius,
+            cooldownSeconds = cooldownSeconds,
         })
     end
 end
@@ -246,7 +307,7 @@ end
 -----------------------------------------------------------
 
 handlers["DebugPlaceWire"] = function(player, args)
-    if not DeadwireConfig.DEBUG and not player:getRole():hasCapability(Capability.CanBuildAnywhere) then
+    if not DeadwireConfig.DEBUG and not isPrivileged(player) then
         return
     end
 
@@ -283,7 +344,7 @@ end
 -----------------------------------------------------------
 
 handlers["DebugListWires"] = function(player, args)
-    if not DeadwireConfig.DEBUG and not player:getRole():hasCapability(Capability.CanBuildAnywhere) then
+    if not DeadwireConfig.DEBUG and not isPrivileged(player) then
         return
     end
 

--- a/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/Config.lua
+++ b/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/Config.lua
@@ -35,6 +35,11 @@ DeadwireConfig.Tiers = {
 
 -----------------------------------------------------------
 -- Wire Property Defaults (overridden by SandboxVars)
+--
+-- cooldownSeconds is REAL seconds, not game time. See the cooldown section of
+-- WireNetwork.lua for why (#16). Reinforced and Bell currently differ only in
+-- sound clip and radius; the cooldown is the obvious lever to separate them
+-- and is deliberately left equal pending a balance decision.
 -----------------------------------------------------------
 DeadwireConfig.WireDefaults = {
     tin_can_tripline = {

--- a/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/WireNetwork.lua
+++ b/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/WireNetwork.lua
@@ -192,19 +192,37 @@ end
 
 -----------------------------------------------------------
 -- Cooldown
+--
+-- Measured in real seconds (os.time), not game hours. The cooldown exists to
+-- stop one zombie crowd spamming the same alarm, which is a real-time problem:
+-- under game time the same config number meant a different real duration on
+-- every server, and at the default day length 36 game-seconds worked out to
+-- about 1.5 real seconds -- shorter than Detection's own dedup window, so the
+-- cooldown did essentially nothing. Fixes #16.
+--
+-- Detection.lua already uses os.time() for its dedup window, so both clocks in
+-- this mod now agree.
 -----------------------------------------------------------
 
 function DeadwireNetwork.isOnCooldown(x, y, z)
     local entry = tileIndex[DeadwireNetwork.tileKey(x, y, z)]
     if not entry or entry.cooldownUntil <= 0 then return false end
-    return getGameTime():getWorldAgeHours() < entry.cooldownUntil
+    return os.time() < entry.cooldownUntil
 end
 
-function DeadwireNetwork.setCooldown(x, y, z, durationHours)
+-- Returns the duration actually applied, or nil if there is no such tile, so
+-- the server can tell clients how long to mirror it for.
+--
+-- Deliberately a duration and not an absolute expiry: server and clients are
+-- different machines, and while os.time() is UTC epoch (so timezone is not a
+-- factor) their wall clocks can still be skewed. Each side adds the duration
+-- to its own clock, which costs network latency in accuracy and is immune to
+-- skew -- the far worse error.
+function DeadwireNetwork.setCooldown(x, y, z, durationSeconds)
     local entry = tileIndex[DeadwireNetwork.tileKey(x, y, z)]
-    if entry then
-        entry.cooldownUntil = getGameTime():getWorldAgeHours() + durationHours
-    end
+    if not entry then return nil end
+    entry.cooldownUntil = os.time() + durationSeconds
+    return durationSeconds
 end
 
 -----------------------------------------------------------

--- a/Contents/mods/Deadwire/42/media/scripts/deadwire_recipes.txt
+++ b/Contents/mods/Deadwire/42/media/scripts/deadwire_recipes.txt
@@ -22,8 +22,8 @@ module Base
         time = 200,
         Tags = AnySurfaceCraft,
         category = Deadwire,
-        SkillRequired = Carpentry:2;Trapping:2,
-        xpAward = Carpentry:15;Trapping:15,
+        SkillRequired = Woodwork:2;Trapping:2,
+        xpAward = Woodwork:15;Trapping:15,
         inputs
         {
             item 1 [Base.Wire],
@@ -42,8 +42,8 @@ module Base
         time = 200,
         Tags = AnySurfaceCraft,
         category = Deadwire,
-        SkillRequired = Carpentry:2;Trapping:2,
-        xpAward = Carpentry:15;Trapping:15,
+        SkillRequired = Woodwork:2;Trapping:2,
+        xpAward = Woodwork:15;Trapping:15,
         inputs
         {
             item 1 [Base.Wire],

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,11 +2,24 @@
 
 ## Current Priority
 
-**Fix #17 and #18, then #14/#15/#16, then finish the in-game smoke test**
+**In-game smoke test. Everything that remains needs PZ actually running.**
 
-#17 and #18 are one-line fixes that between them revive the entire camouflage system, which has never worked in either direction.
+All five open code bugs (#14 through #18) are fixed, tested and merged. There are no
+open code bugs. What there is instead is a mod that has never been confirmed working:
+sprites, recipes, loot tables, sounds and the whole camouflage path are unverified in
+a live game. The camouflage path in particular has never worked in either direction
+until now, so it has no history of behaving at all.
 
-**Blocker for release:** world sprite *art* is placeholder. The `deadwire_01` tilesheet does ship (`.pack` + `.tiles`, both declared in mod.info), so the `construction_01_24` fallback should never fire — but that is unverified, and the 8 images in the sheet are Session 10 placeholders rather than the finished Gemini art. Source PNGs sit at repo root pending crop/resize and a tilesheet rebuild.
+Run `python scripts/verify_names.py` before any commit that touches a game name. It
+resolves all 67 references against the installed 42.20 and is the reason two bugs
+nobody had filed turned up in Session 17.
+
+**Blocker for release:** world sprite *art* is placeholder. The `deadwire_01` tilesheet
+ships (`.pack` + `.tiles`, both declared in mod.info) and its 8 tile indices provably
+match the names `Config.Sprites` asks for, so the `construction_01_24` fallback should
+never fire — but that is still unverified in-game, and the 8 images are Session 10
+placeholders rather than the finished Gemini art. Source PNGs sit at repo root pending
+crop/resize and a tilesheet rebuild.
 
 ---
 
@@ -17,10 +30,11 @@
 | Sprint 1 (Foundation) | **PASSED** | In-game, Session 6 |
 | Sprint 2 (Placement) | **PASSED** | In-game, Session 8 |
 | Sprint 3 (Sound+Trigger) | **Partly verified** | Items + globals confirmed in-game S16. Sprites, recipes, sounds still untested |
-| Sprint 4 (Camo+Config) | **Broken** | Both halves dead: #17 and #18 |
-| 42.20.2 compat | **Audited** | Six silent failures found, three fixed in 4537d2c |
-| Custom world sprites | **Placeholder art** | Tilesheet ships and should load; images are S10 placeholders. Release blocker |
-| Test harness | **Done** | 131 tests — `run_tests.bat` |
+| Sprint 4 (Camo+Config) | **Fixed, untested** | #17 + #18 closed S17. Never worked before, so no prior behaviour to compare against |
+| 42.20.2 compat | **Audited + tooled** | 8 silent failures total. `scripts/verify_names.py` now checks all 67 names |
+| MP hardening | **Done, untested** | #15 closed S17: trigger proximity + server-side kit consumption |
+| Custom world sprites | **Placeholder art** | Tilesheet ships, names provably match. Images are S10 placeholders. Release blocker |
+| Test harness | **Done** | 143 tests — `run_tests.bat` |
 | pz-test-pilot harness | **Working** | Can drive the live game, see To Resume in context.md |
 
 ---
@@ -29,13 +43,10 @@
 
 | # | Title | Severity |
 |---|-------|----------|
-| 18 | Rain never degrades camouflage: the entire Climate API call is wrong | High |
-| 17 | Camouflage skill scaling is dead: `Perks.Foraging` does not exist | High |
-| 16 | Wire cooldown written in seconds, measured in game time | Medium |
-| 15 | MP: server trusts client on wire triggers and kit consumption | Medium |
-| 14 | Admin wire removal broken: `Capability.CanBuildAnywhere` does not exist | Medium |
 | 13 | Tier 3: electrified perimeter wire (generator-powered) | Phase 3 |
-| 12 | Loot distribution for metalworking rooms | Code fixed S16, needs in-game confirm |
+| 12 | Loot distribution for metalworking rooms | Code correct + name-verified, needs in-game confirm |
+
+Closed in Session 17: #14, #15, #16, #17, #18.
 
 ---
 
@@ -51,8 +62,11 @@
 
 | Decision | Rationale | Date |
 |----------|-----------|------|
+| Name checking is a committed script, not a technique | S16 verified by hand and wrote the method into context.md. The next hand-written name (`ChurchStorageMisc`) was wrong and shipped labelled "verified". A checked claim with no artifact decays to an unchecked one. | 2026-08-05 |
+| Read declared fields/methods, not the constant pool | A pool grep matches any string anywhere in the class, so it passes `Perks.Foraging`. Also: `Perks` is not an enum, it is a holder of public static final fields. | 2026-08-05 |
+| A missing loot distribution logs a warning | The existence check was silently skipping. Every bug this file had was a nil name with a clean log. | 2026-08-05 |
+| Cooldowns in real seconds, broadcast as a duration | Game time made the same config number mean a different real duration per server. Duration not absolute time, because server and clients are different machines with skewed clocks. | 2026-08-05 |
 | No guards around unverified API names | A guard around a typo is indistinguishable from a guard around a real fallback. Cost three dead features. | 2026-08-05 |
-| Verify names against the jar constant pool | Substring-matching the vanilla Lua tree gives false negatives: it passes `Perks.Foraging`. | 2026-08-05 |
 | Loot uses `.items` flat pairs | Matches vanilla on 42.20. The 42.16 `weightChance` rule applies to `procList`, not `.items`. | 2026-08-05 |
 | Explicit item lists over `tags[...]` for Tanglefoot | A recipe line is an item list or a tags list, never both, and Stake carries `tentpeg` not `woodhandle`. | 2026-08-05 |
 | No RecalcAllWithNeighbours on wire place | Trip wires must be pathfinding-transparent. Recalc only on removal. Fixes #8. | 2026-03-11 |
@@ -72,18 +86,34 @@ All checked against the installed 42.20 jar in Session 16. This table used to ca
 
 | Item | Verdict |
 |------|---------|
-| `Perks.Foraging` | **WRONG** — it is `Perks.PlantScavenging`. Issue #17 |
-| `Climate.GetInstance():getRainStrength()` | **WRONG** on every identifier. Issue #18 |
-| `Capability.CanBuildAnywhere` | **DOES NOT EXIST**. Issue #14 |
+| `Perks.Foraging` | **WRONG** — it is `Perks.PlantScavenging`. Fixed S17, #17 |
+| `Climate.GetInstance():getRainStrength()` | **WRONG** on every identifier — it is `getClimateManager():getRainIntensity()`. Fixed S17, #18 |
+| `Capability.CanBuildAnywhere` | **DOES NOT EXIST** — it is `UseBuildCheat`. Fixed S17 in all 3 places, #14 |
+| `ChurchStorageMisc` | **DOES NOT EXIST** — 42.20 has no church distribution at all. Found and fixed S17 |
+| Recipe `SkillRequired = Carpentry` | **NOT A PERK** — it is `Woodwork`. Found and fixed S17 |
+| Rain intensity range | **0.0-1.0**, from vanilla's own use of the sibling intensity getters |
+| `Woodwork` / `PlantScavenging` display names | Show as "Carpentry" / "Foraging". Existing tooltips are correct, deliberately unchanged |
 | `setOutlineHighlight` / `setOutlineHighlightCol` | Exist. Fine |
 | `BodyPartType.Foot_L` | Exists. Fine |
-| Issue #12 dist names | Were wrong, fixed in 4537d2c against verified vanilla names |
 
 Still open: `sendServerCommand(player, module, cmd, args)` targeted send, used in WireNetworkSync. Verify by reconnecting in MP.
 
 ---
 
 ## Session History
+
+### Session 17 (2026-08-05): all five code bugs closed, name verifier built
+
+Built `scripts/verify_names.py` + `scripts/pzclass.py` *before* fixing anything, on the
+grounds that S16's hand-verification had already decayed — and it immediately found two
+bugs nobody had filed (`ChurchStorageMisc`, and `Carpentry` in both Tier 1 recipes).
+
+Closed #14/#15/#16/#17/#18. Two of them were larger than the issue said: #14 named one
+`CanBuildAnywhere` site and there were three, and #16's real damage was that the server
+set cooldowns while the client checked them, so MP cooldowns never applied at all.
+
+Tests 131 → 143. The five new #15 tests were confirmed to fail with the guards removed,
+so they are not vacuous. Nothing was tested against a running game.
 
 ### Session 16 (2026-08-05): B42.20.2 audit
 

--- a/scripts/pzclass.py
+++ b/scripts/pzclass.py
@@ -1,0 +1,152 @@
+"""Minimal Java .class reader for resolving Project Zomboid API names.
+
+Parses the constant pool and the field/method tables of a class inside
+projectzomboid.jar. Used to answer one question exactly: does this name
+actually exist in the installed game?
+
+Why fields and methods rather than a raw constant-pool grep: a constant-pool
+grep matches any string that happens to appear anywhere in the class, so it
+reports `Perks.Foraging` as valid because the word "Foraging" is in some
+unrelated literal. Six of the seven bugs found in Session 16, and the
+ChurchStorageMisc bug found in Session 17, were that exact false positive.
+"""
+
+import struct
+import zipfile
+
+# Constant pool tags that carry a payload we must skip over correctly.
+_TAG_UTF8 = 1
+_TAG_INT = 3
+_TAG_FLOAT = 4
+_TAG_LONG = 5
+_TAG_DOUBLE = 6
+_TAG_CLASS = 7
+_TAG_STRING = 8
+_TAG_FIELDREF = 9
+_TAG_METHODREF = 10
+_TAG_IFACEREF = 11
+_TAG_NAMEANDTYPE = 12
+_TAG_HANDLE = 15
+_TAG_METHODTYPE = 16
+_TAG_DYNAMIC = 17
+_TAG_INVOKEDYNAMIC = 18
+_TAG_MODULE = 19
+_TAG_PACKAGE = 20
+
+# tag -> number of bytes to skip after the tag byte
+_FIXED_WIDTH = {
+    _TAG_INT: 4, _TAG_FLOAT: 4, _TAG_LONG: 8, _TAG_DOUBLE: 8,
+    _TAG_CLASS: 2, _TAG_STRING: 2, _TAG_FIELDREF: 4, _TAG_METHODREF: 4,
+    _TAG_IFACEREF: 4, _TAG_NAMEANDTYPE: 4, _TAG_HANDLE: 3,
+    _TAG_METHODTYPE: 2, _TAG_DYNAMIC: 4, _TAG_INVOKEDYNAMIC: 4,
+    _TAG_MODULE: 2, _TAG_PACKAGE: 2,
+}
+
+ACC_PUBLIC = 0x0001
+ACC_STATIC = 0x0008
+ACC_FINAL = 0x0010
+ACC_ENUM = 0x4000
+
+
+class ClassFile:
+    def __init__(self, pool, fields, methods):
+        self.pool = pool          # index -> str for UTF8 entries, else None
+        self.fields = fields      # list of (name, descriptor, access_flags)
+        self.methods = methods    # list of (name, descriptor, access_flags)
+
+    def field_names(self, static_only=False):
+        return {n for n, _d, f in self.fields
+                if not static_only or (f & ACC_STATIC)}
+
+    def enum_constants(self):
+        """Static fields flagged ACC_ENUM: the enum's declared constants."""
+        return {n for n, _d, f in self.fields if (f & ACC_ENUM)}
+
+    def constants(self):
+        """Names usable as `ClassName.NAME` from Lua.
+
+        Covers both shapes PZ uses: a true Java enum (ACC_ENUM constants,
+        e.g. Capability) and a plain holder class of public static final
+        fields (e.g. PerkFactory$Perks, which is NOT an enum despite Lua
+        code treating `Perks.X` like one).
+        """
+        want = ACC_PUBLIC | ACC_STATIC | ACC_FINAL
+        return {n for n, _d, f in self.fields
+                if (f & ACC_ENUM) or (f & want) == want}
+
+    def method_names(self):
+        return {n for n, _d, _f in self.methods}
+
+
+def _read_pool(data, off):
+    count = struct.unpack_from(">H", data, off)[0]
+    off += 2
+    pool = [None] * count
+    i = 1
+    while i < count:
+        tag = data[off]
+        off += 1
+        if tag == _TAG_UTF8:
+            length = struct.unpack_from(">H", data, off)[0]
+            off += 2
+            pool[i] = data[off:off + length].decode("utf-8", "replace")
+            off += length
+        else:
+            width = _FIXED_WIDTH.get(tag)
+            if width is None:
+                raise ValueError("unknown constant pool tag %d at %d" % (tag, off - 1))
+            off += width
+        # long and double occupy two pool slots (JVMS 4.4.5)
+        i += 2 if tag in (_TAG_LONG, _TAG_DOUBLE) else 1
+    return pool, off
+
+
+def _read_members(data, off, pool):
+    count = struct.unpack_from(">H", data, off)[0]
+    off += 2
+    out = []
+    for _ in range(count):
+        access, name_i, desc_i, attr_count = struct.unpack_from(">HHHH", data, off)
+        off += 8
+        for _a in range(attr_count):
+            attr_len = struct.unpack_from(">I", data, off + 2)[0]
+            off += 6 + attr_len
+        out.append((pool[name_i], pool[desc_i], access))
+    return out, off
+
+
+def parse(data):
+    if data[:4] != b"\xca\xfe\xba\xbe":
+        raise ValueError("not a class file")
+    off = 8                                   # magic + minor + major
+    pool, off = _read_pool(data, off)
+    off += 6                                  # access_flags, this_class, super_class
+    iface_count = struct.unpack_from(">H", data, off)[0]
+    off += 2 + iface_count * 2
+    fields, off = _read_members(data, off, pool)
+    methods, off = _read_members(data, off, pool)
+    return ClassFile(pool, fields, methods)
+
+
+class Jar:
+    """Lazy accessor for classes inside projectzomboid.jar."""
+
+    def __init__(self, jar_path):
+        self._zip = zipfile.ZipFile(jar_path)
+        self._cache = {}
+
+    def klass(self, path):
+        """path e.g. 'zombie/characters/Capability'"""
+        if path not in self._cache:
+            self._cache[path] = parse(self._zip.read(path + ".class"))
+        return self._cache[path]
+
+    def has_class(self, path):
+        try:
+            self._zip.getinfo(path + ".class")
+            return True
+        except KeyError:
+            return False
+
+    def class_paths(self):
+        return [n[:-6] for n in self._zip.namelist() if n.endswith(".class")]

--- a/scripts/verify_names.py
+++ b/scripts/verify_names.py
@@ -1,0 +1,288 @@
+"""Resolve every game name Deadwire references against the installed game.
+
+Run:  python scripts/verify_names.py [--pz <ProjectZomboid dir>]
+
+Exit code 0 if every name resolves, 1 otherwise.
+
+This exists because the whole class of bug that has cost this project the most
+is a name that looks right and silently does not exist: Perks.Foraging,
+Capability.CanBuildAnywhere, Base.TreeBranch, ChurchStorageMisc. None of them
+error at load. The feature just never happens. `pz-mod-checker scan` does not
+catch these -- it is a version-keyed rule engine with no concept of whether a
+name resolves.
+
+Checked categories (each has hard ground truth in the install):
+  Perks.X              PerkFactory$Perks static fields
+  Capability.X         Capability enum constants
+  BodyPartType.X       BodyPartType enum constants
+  Base.X               vanilla generated item scripts + this mod's own items
+  distribution names   ProceduralDistributions.list keys
+  SkillRequired/xpAward  perk names inside craftRecipe blocks
+  Icon = X             media/textures/Item_X.png must exist
+  sprite names         this mod's own .tiles.txt tile indices
+
+Deliberately NOT checked: bare global function names. Many legitimate globals
+are defined in vanilla Lua rather than exposed from Java, so a Java-only check
+reports false positives, and a checker that cries wolf stops being read.
+"""
+
+import argparse
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pzclass import Jar  # noqa: E402
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MOD = os.path.join(REPO, "Contents", "mods", "Deadwire", "42", "media")
+
+DEFAULT_PZ = r"C:/Program Files (x86)/Steam/steamapps/common/ProjectZomboid"
+
+# Item ids referenced with a module prefix this checker cannot resolve are
+# skipped rather than reported; only Base.* has a single unambiguous source.
+ITEM_RE = re.compile(r"\bBase\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+class Report:
+    def __init__(self):
+        self.problems = []
+        self.checked = 0
+
+    def ok(self, _category, _name):
+        self.checked += 1
+
+    def bad(self, category, name, where, hint=""):
+        self.checked += 1
+        self.problems.append((category, name, where, hint))
+
+    def check(self, category, name, valid, where, universe=None):
+        if name in valid:
+            self.ok(category, name)
+        else:
+            self.bad(category, name, where, near(name, universe or valid))
+
+
+def near(name, universe):
+    """Cheap nearest-name hint: same prefix, or same lowercase spelling."""
+    low = name.lower()
+    exact = [c for c in universe if c.lower() == low]
+    if exact:
+        return "did you mean %s" % exact[0]
+    pre = sorted(c for c in universe if c.lower().startswith(low[:4]))[:4]
+    return ("closest: " + ", ".join(pre)) if pre else ""
+
+
+# ---------------------------------------------------------------- ground truth
+
+def vanilla_items(pz):
+    """Every `item X` declared inside `module Base` in the generated scripts."""
+    items = set()
+    root = os.path.join(pz, "media", "scripts")
+    for dirpath, _dirs, files in os.walk(root):
+        for fn in files:
+            if not fn.endswith(".txt"):
+                continue
+            path = os.path.join(dirpath, fn)
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                src = fh.read()
+            for m in re.finditer(r"^\s*item\s+([A-Za-z_][A-Za-z0-9_]*)\s*$",
+                                 src, re.M):
+                items.add(m.group(1))
+    return items
+
+
+def vanilla_distributions(pz):
+    path = os.path.join(pz, "media", "lua", "server", "Items",
+                        "ProceduralDistributions.lua")
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        src = fh.read()
+    return set(re.findall(r"^\t([A-Za-z_][A-Za-z0-9_]*)\s*=\s*\{", src, re.M))
+
+
+def mod_items():
+    path = os.path.join(MOD, "scripts", "deadwire_items.txt")
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        src = fh.read()
+    return set(re.findall(r"^\s*item\s+([A-Za-z_][A-Za-z0-9_]*)\s*$", src, re.M))
+
+
+def mod_sprites():
+    """Tile names the mod's own tilesheet actually defines."""
+    path = os.path.join(MOD, "deadwire_01.tiles.txt")
+    if not os.path.exists(path):
+        return set()
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        src = fh.read()
+    name = re.search(r"file\s*=\s*(\S+)", src)
+    if not name:
+        return set()
+    count = len(re.findall(r"^\s*tile\s*$", src, re.M))
+    return {"%s_%d" % (name.group(1), i) for i in range(count)}
+
+
+def lua_files():
+    out = []
+    for dirpath, _dirs, files in os.walk(os.path.join(MOD, "lua")):
+        for fn in files:
+            if fn.endswith(".lua"):
+                out.append(os.path.join(dirpath, fn))
+    return sorted(out)
+
+
+def script_files():
+    d = os.path.join(MOD, "scripts")
+    return sorted(os.path.join(d, f) for f in os.listdir(d) if f.endswith(".txt"))
+
+
+def rel(path):
+    return os.path.relpath(path, REPO).replace("\\", "/")
+
+
+# ---------------------------------------------------------------------- checks
+
+def check_lua(rep, jar, items, dists):
+    perks = jar.klass("zombie/characters/skills/PerkFactory$Perks").constants()
+    caps = jar.klass("zombie/characters/Capability").constants()
+    bodyparts = jar.klass("zombie/characters/BodyDamage/BodyPartType").constants()
+    sprites = mod_sprites()
+    # The mod's own items are declared in `module Base` too, so Base.Deadwire_*
+    # is legitimate: resolve against vanilla plus this mod's declarations.
+    items = items | mod_items()
+
+    for path in lua_files():
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            src = fh.read()
+        # Comments carry dead example names on purpose; strip them first.
+        code = re.sub(r"--[^\n]*", "", src)
+        where = rel(path)
+
+        for name in set(re.findall(r"\bPerks\.([A-Za-z_][A-Za-z0-9_]*)", code)):
+            rep.check("Perks", name, perks, where)
+        for name in set(re.findall(r"\bCapability\.([A-Za-z_][A-Za-z0-9_]*)", code)):
+            rep.check("Capability", name, caps, where)
+        for name in set(re.findall(r"\bBodyPartType\.([A-Za-z_][A-Za-z0-9_]*)", code)):
+            rep.check("BodyPartType", name, bodyparts, where)
+        for name in set(ITEM_RE.findall(code)):
+            rep.check("item", "Base." + name, {"Base." + i for i in items}, where,
+                      universe=items)
+        for name in set(re.findall(r'"(deadwire_01_\d+)"', code)):
+            rep.check("sprite", name, sprites, where)
+
+        # Distribution names live in `local <x>Dists = { "A", "B" }` tables.
+        for block in re.findall(r"local\s+\w*[Dd]ists\s*=\s*\{(.*?)\}", code, re.S):
+            for name in re.findall(r'"([A-Za-z_][A-Za-z0-9_]*)"', block):
+                rep.check("distribution", name, dists, where)
+
+
+def check_scripts(rep, jar, items):
+    perks = jar.klass("zombie/characters/skills/PerkFactory$Perks").constants()
+    all_items = items | mod_items()
+
+    for path in script_files():
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            src = fh.read()
+        code = re.sub(r"//[^\n]*", "", src)
+        where = rel(path)
+
+        for name in set(ITEM_RE.findall(code)):
+            rep.check("item", "Base." + name,
+                      {"Base." + i for i in all_items}, where, universe=all_items)
+
+        # SkillRequired = Perk:Level;Perk:Level  (same grammar for xpAward)
+        for field in ("SkillRequired", "xpAward"):
+            for m in re.finditer(field + r"\s*=\s*([^,\n}]+)", code):
+                for pair in m.group(1).split(";"):
+                    pair = pair.strip()
+                    if not pair:
+                        continue
+                    perk = pair.split(":")[0].strip()
+                    if perk:
+                        rep.check("recipe skill", perk, perks, where)
+
+        for name in set(re.findall(r"^\s*Icon\s*=\s*([A-Za-z0-9_]+)", code, re.M)):
+            png = os.path.join(MOD, "textures", "Item_%s.png" % name)
+            if os.path.exists(png):
+                rep.ok("icon", name)
+            else:
+                rep.bad("icon", name, where,
+                        "expected media/textures/Item_%s.png" % name)
+
+
+def check_config_sprites(rep):
+    """Config.Sprites must name tiles the shipped tilesheet defines."""
+    sprites = mod_sprites()
+    if not sprites:
+        rep.bad("tilesheet", "deadwire_01.tiles.txt", "media/",
+                "tilesheet definition missing or unparseable")
+        return
+    fallback = os.path.join(MOD, "texturepacks", "deadwire_01.pack")
+    if not os.path.exists(fallback):
+        rep.bad("tilesheet", "deadwire_01.pack", "media/texturepacks/",
+                "declared in mod.info but not present")
+    else:
+        rep.ok("tilesheet", "deadwire_01.pack")
+
+
+def check_modinfo(rep):
+    """Both mod.info files must agree; B42 reads 42/ but the root one is required."""
+    def parse(path):
+        d = {}
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                if "=" in line and not line.strip().startswith("#"):
+                    k, v = line.split("=", 1)
+                    d[k.strip()] = v.strip()
+        return d
+
+    root = parse(os.path.join(REPO, "Contents", "mods", "Deadwire", "mod.info"))
+    inner = parse(os.path.join(REPO, "Contents", "mods", "Deadwire", "42", "mod.info"))
+    for key in ("name", "id", "modversion", "versionMin", "poster", "pack", "tiledef"):
+        a, b = root.get(key), inner.get(key)
+        if a == b:
+            rep.ok("mod.info", key)
+        else:
+            rep.bad("mod.info", key, "Contents/mods/Deadwire/mod.info",
+                    "root=%r vs 42/=%r" % (a, b))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pz", default=DEFAULT_PZ, help="Project Zomboid install dir")
+    args = ap.parse_args()
+
+    jar_path = os.path.join(args.pz, "projectzomboid.jar")
+    if not os.path.exists(jar_path):
+        print("ERROR: no projectzomboid.jar at %s" % jar_path)
+        print("Pass --pz <install dir>.")
+        return 2
+
+    jar = Jar(jar_path)
+    items = vanilla_items(args.pz)
+    dists = vanilla_distributions(args.pz)
+
+    rep = Report()
+    check_lua(rep, jar, items, dists)
+    check_scripts(rep, jar, items)
+    check_config_sprites(rep)
+    check_modinfo(rep)
+
+    print("verify_names: %d references checked against %s"
+          % (rep.checked, os.path.basename(args.pz)))
+    print("  vanilla items: %d   distributions: %d" % (len(items), len(dists)))
+
+    if not rep.problems:
+        print("\nAll names resolve.")
+        return 0
+
+    print("\n%d UNRESOLVED:\n" % len(rep.problems))
+    width = max(len(c) for c, _n, _w, _h in rep.problems)
+    for category, name, where, hint in rep.problems:
+        print("  %-*s  %-34s %s" % (width, category, name, where))
+        if hint:
+            print("  %-*s  %s" % (width, "", hint))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stubs.lua
+++ b/tests/stubs.lua
@@ -148,8 +148,12 @@ function _setOsTime(t) _osTime = t end   -- test control
 
 -----------------------------------------------------------------
 -- PZ capability system stub
+-- UseBuildCheat is the real 42.20 name. CanBuildAnywhere, which this stub
+-- used to declare, does not exist in the game -- so the stub was validating
+-- a call that could never work. Deliberately the only key defined: any other
+-- Capability.X in mod code resolves to nil here and fails loudly.
 -----------------------------------------------------------------
-Capability = { CanBuildAnywhere = "CanBuildAnywhere" }
+Capability = { UseBuildCheat = "UseBuildCheat" }
 
 -----------------------------------------------------------------
 -- Sound stubs (no-op; we only care about logic, not audio)
@@ -184,14 +188,58 @@ function _mockZombie(x, y, z, alive)
     }
 end
 
+-- Inventory stub: only the container methods Deadwire actually calls.
+local function _makeInventory()
+    local inv = { _items = {} }
+    inv.getFirstTypeRecurse = function(self, fullType)
+        for _, it in ipairs(self._items) do
+            if it.fullType == fullType then return it end
+        end
+        return nil
+    end
+    inv.getItemsFromFullType = function(self, fullType, _recurse)
+        local found = {}
+        for _, it in ipairs(self._items) do
+            if it.fullType == fullType then table.insert(found, it) end
+        end
+        return {
+            size = function() return #found end,
+            get  = function(_, i) return found[i + 1] end,
+        }
+    end
+    inv.Remove = function(self, item)
+        for i, it in ipairs(self._items) do
+            if it == item then table.remove(self._items, i); return end
+        end
+    end
+    return inv
+end
+
+-- Put an item in a mock player's inventory. Returns the item table.
+function _giveItem(player, fullType)
+    local item = { fullType = fullType }
+    table.insert(player:getInventory()._items, item)
+    return item
+end
+
+function _countItems(player, fullType)
+    local n = 0
+    for _, it in ipairs(player:getInventory()._items) do
+        if it.fullType == fullType then n = n + 1 end
+    end
+    return n
+end
+
 function _mockPlayer(x, y, z, username)
     local modData = {}
     local sq = _squares[x .. "," .. y .. "," .. z]
+    local inv = _makeInventory()
     return {
         isAlive       = function() return true end,
         getSquare     = function() return sq end,
         getModData    = function() return modData end,
         getUsername   = function() return username or "testplayer" end,
+        getInventory  = function() return inv end,
         isAccessLevel = function() return false end,
         getRole       = function() return {
             hasCapability = function() return false end
@@ -203,8 +251,16 @@ function _mockAdmin(x, y, z, username)
     local p = _mockPlayer(x, y, z, username)
     p.isAccessLevel = function() return true end
     p.getRole = function() return {
-        hasCapability = function() return true end
+        hasCapability = function(_, cap) return cap == Capability.UseBuildCheat end
     } end
+    return p
+end
+
+-- A player whose getRole() returns nil, as happens in single player. This used
+-- to throw on `player:getRole():hasCapability(...)`.
+function _mockRolelessPlayer(x, y, z, username)
+    local p = _mockPlayer(x, y, z, username)
+    p.getRole = function() return nil end
     return p
 end
 

--- a/tests/test_server_commands.lua
+++ b/tests/test_server_commands.lua
@@ -34,6 +34,18 @@ local function resetAll()
     _clearCommands()
 end
 
+-- A player holding the kit for `wireType` (default: tin can).
+--
+-- PlaceWire now refuses a player who is not carrying the kit (#15), so every
+-- PlaceWire test needs one -- otherwise the no-op tests below would pass
+-- because the player is empty-handed rather than because of the condition
+-- each is actually meant to exercise.
+local function _kittedPlayer(x, y, z, name, wireType)
+    local player = _mockPlayer(x, y, z, name)
+    _giveItem(player, DeadwireConfig.KitItems[wireType or "tin_can_tripline"])
+    return player
+end
+
 -----------------------------------------------------------------
 -- PlaceWire tests
 -----------------------------------------------------------------
@@ -42,7 +54,7 @@ suite("ServerCommands: PlaceWire")
 test("valid args and empty tile: createWire called, WirePlaced broadcast sent", function()
     resetAll()
     local sq = _makeSquare(10, 20, 0)
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
@@ -64,7 +76,7 @@ end)
 test("missing wireType: no-op", function()
     resetAll()
     local sq = _makeSquare(10, 20, 0)
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0
@@ -77,7 +89,7 @@ end)
 
 test("missing position: no-op", function()
     resetAll()
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         wireType = "tin_can_tripline"
@@ -90,7 +102,7 @@ end)
 test("unknown wireType: no-op", function()
     resetAll()
     local sq = _makeSquare(10, 20, 0)
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0, wireType = "definitely_not_a_wire"
@@ -102,7 +114,7 @@ end)
 test("no square at position: no-op", function()
     resetAll()
     -- Square at (99,99,0) is NOT created, so getCell():getGridSquare returns nil
-    local player = _mockPlayer(0, 0, 0, "alice")
+    local player = _kittedPlayer(0, 0, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 99, y = 99, z = 0, wireType = "tin_can_tripline"
@@ -117,7 +129,7 @@ test("tile already occupied: no-op", function()
     -- Pre-register a wire so the tile is occupied
     DeadwireNetwork.registerTile(10, 20, 0, 99, "tin_can_tripline", "bob")
 
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
@@ -136,7 +148,7 @@ test("player at wire limit (WireMaxPerPlayer=1, one wire already placed): no-op"
     SandboxVars.Deadwire.WireMaxPerPlayer = 1
 
     local sq2 = _makeSquare(2, 2, 0)
-    local player = _mockPlayer(2, 2, 0, "alice")
+    local player = _kittedPlayer(2, 2, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 2, y = 2, z = 0, wireType = "tin_can_tripline"
@@ -150,7 +162,7 @@ test("disabled tier (EnableTier0=false, tin_can): no-op", function()
     SandboxVars.Deadwire.EnableTier0 = false
 
     local sq = _makeSquare(10, 20, 0)
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
@@ -164,13 +176,72 @@ test("EnableMod=false: no-op", function()
     SandboxVars.Deadwire.EnableMod = false
 
     local sq = _makeSquare(10, 20, 0)
-    local player = _mockPlayer(10, 20, 0, "alice")
+    local player = _kittedPlayer(10, 20, 0, "alice")
 
     Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
         x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
     })
 
     assert_eq(#_createdWires, 0, "createWire should NOT be called when mod is disabled")
+end)
+
+-- #15: PlaceWire is a plain server command, so a modified client can send it
+-- without ever having crafted anything. The server must check the inventory.
+
+test("player without the kit: no-op (#15)", function()
+    resetAll()
+    local sq = _makeSquare(10, 20, 0)
+    local player = _mockPlayer(10, 20, 0, "mallory")   -- empty-handed
+
+    Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
+        x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_createdWires, 0, "createWire should NOT be called without a kit")
+    assert_nil(_findServerCmd("WirePlaced"), "WirePlaced should NOT have been sent")
+end)
+
+test("holding the wrong kit does not authorize placement (#15)", function()
+    resetAll()
+    local sq = _makeSquare(10, 20, 0)
+    local player = _mockPlayer(10, 20, 0, "mallory")
+    _giveItem(player, DeadwireConfig.KitItems.bell_tripline)
+
+    Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
+        x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_createdWires, 0, "a bell kit must not place a tin can wire")
+end)
+
+test("successful placement consumes exactly one kit (#15)", function()
+    resetAll()
+    local sq = _makeSquare(10, 20, 0)
+    local player = _kittedPlayer(10, 20, 0, "alice")
+    _giveItem(player, DeadwireConfig.KitItems.tin_can_tripline)   -- two in total
+
+    Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
+        x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_createdWires, 1, "createWire should have been called")
+    assert_eq(_countItems(player, DeadwireConfig.KitItems.tin_can_tripline), 1,
+        "exactly one kit should have been consumed")
+end)
+
+test("failed placement consumes no kit (#15)", function()
+    resetAll()
+    local sq = _makeSquare(10, 20, 0)
+    DeadwireNetwork.registerTile(10, 20, 0, 99, "tin_can_tripline", "bob")  -- occupied
+    local player = _kittedPlayer(10, 20, 0, "alice")
+
+    Events.OnClientCommand:Fire("Deadwire", "PlaceWire", player, {
+        x = 10, y = 20, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_createdWires, 0, "placement should have been refused")
+    assert_eq(_countItems(player, DeadwireConfig.KitItems.tin_can_tripline), 1,
+        "kit must survive a refused placement")
 end)
 
 -----------------------------------------------------------------
@@ -214,6 +285,37 @@ test("non-owner, non-admin cannot remove wire: no-op", function()
 
     assert_eq(#_destroyedWires, 0, "non-owner should not be able to remove wire")
     assert_nil(_findServerCmd("WireDestroyed"))
+end)
+
+-- #14: the old check called Capability.CanBuildAnywhere, which does not exist
+-- in 42.20, and called it on getRole() without a nil guard.
+
+test("non-owner with no role is denied, not an error (#14)", function()
+    resetAll()
+    local sq = _makeSquare(5, 5, 0)
+    DeadwireNetwork.registerTile(5, 5, 0, 1, "tin_can_tripline", "alice")
+
+    local player = _mockRolelessPlayer(5, 5, 0, "bob")
+
+    Events.OnClientCommand:Fire("Deadwire", "RemoveWire", player, {
+        x = 5, y = 5, z = 0
+    })
+
+    assert_eq(#_destroyedWires, 0, "roleless non-owner must be denied")
+end)
+
+test("owner with no role can still remove their own wire (#14)", function()
+    resetAll()
+    local sq = _makeSquare(5, 5, 0)
+    DeadwireNetwork.registerTile(5, 5, 0, 1, "tin_can_tripline", "alice")
+
+    local player = _mockRolelessPlayer(5, 5, 0, "alice")
+
+    Events.OnClientCommand:Fire("Deadwire", "RemoveWire", player, {
+        x = 5, y = 5, z = 0
+    })
+
+    assert_eq(#_destroyedWires, 1, "ownership must not depend on having a role")
 end)
 
 test("admin removes any wire: destroyWire called", function()
@@ -279,7 +381,7 @@ test("reinforced (breakOnTrigger=false): no destroy, cooldown set, WireTriggered
     local sq = _makeSquare(7, 7, 0)
     DeadwireNetwork.registerTile(7, 7, 0, 1, "reinforced_tripline", "alice")
 
-    _setWorldAge(0)
+    _setOsTime(1000)
     local player = _mockPlayer(7, 7, 0, "bob")
 
     Events.OnClientCommand:Fire("Deadwire", "WireTriggered", player, {
@@ -295,6 +397,80 @@ test("reinforced (breakOnTrigger=false): no destroy, cooldown set, WireTriggered
     local trigCmd = _findServerCmd("WireTriggered")
     assert_not_nil(trigCmd, "WireTriggered sound broadcast should be sent")
     assert_eq(trigCmd.args.soundName, DeadwireConfig.Sounds.WIRE_RATTLE)
+
+    -- Clients run detection against their own copy of the network, so the
+    -- cooldown has to travel with the broadcast or it only exists server-side.
+    assert_eq(trigCmd.args.cooldownSeconds,
+        DeadwireConfig.WireDefaults.reinforced_tripline.cooldownSeconds,
+        "broadcast must carry the cooldown duration for clients to mirror")
+end)
+
+-- #15: detection is necessarily client-side, so the server cannot verify that
+-- a wire fired -- only that the reporter is close enough to have seen it.
+
+test("trigger report from a distant player is rejected (#15)", function()
+    resetAll()
+    local sq = _makeSquare(6, 6, 0)
+    _makeSquare(200, 200, 0)
+    DeadwireNetwork.registerTile(6, 6, 0, 1, "tin_can_tripline", "alice")
+
+    local mallory = _mockPlayer(200, 200, 0, "mallory")
+
+    Events.OnClientCommand:Fire("Deadwire", "WireTriggered", mallory, {
+        x = 6, y = 6, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_destroyedWires, 0, "a distant client must not destroy a wire")
+    assert_nil(_findServerCmd("WireDestroyed"))
+    assert_nil(_findServerCmd("WireTriggered"))
+end)
+
+test("trigger report from a different floor is rejected (#15)", function()
+    resetAll()
+    _makeSquare(6, 6, 0)
+    _makeSquare(6, 6, 1)
+    DeadwireNetwork.registerTile(6, 6, 0, 1, "tin_can_tripline", "alice")
+
+    local mallory = _mockPlayer(6, 6, 1, "mallory")   -- directly above
+
+    Events.OnClientCommand:Fire("Deadwire", "WireTriggered", mallory, {
+        x = 6, y = 6, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_destroyedWires, 0, "z must be an exact match, not a distance")
+end)
+
+test("trigger report from an adjacent tile is accepted (#15)", function()
+    resetAll()
+    _makeSquare(6, 6, 0)
+    _makeSquare(8, 7, 0)
+    DeadwireNetwork.registerTile(6, 6, 0, 1, "tin_can_tripline", "alice")
+
+    local player = _mockPlayer(8, 7, 0, "bob")   -- 2 tiles away, within range
+
+    Events.OnClientCommand:Fire("Deadwire", "WireTriggered", player, {
+        x = 6, y = 6, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_destroyedWires, 1, "a nearby player's report must still be honoured")
+end)
+
+test("camo is not degraded by a distant trigger report (#15)", function()
+    resetAll()
+    _makeSquare(6, 6, 0)
+    _makeSquare(200, 200, 0)
+    DeadwireNetwork.registerTile(6, 6, 0, 1, "reinforced_tripline", "alice")
+    DeadwireNetwork.setCamouflaged(6, 6, 0, true, 100)
+    SandboxVars.Deadwire.CamoTriggerDegrade = 15
+
+    local mallory = _mockPlayer(200, 200, 0, "mallory")
+
+    Events.OnClientCommand:Fire("Deadwire", "WireTriggered", mallory, {
+        x = 6, y = 6, z = 0, wireType = "reinforced_tripline"
+    })
+
+    assert_eq(DeadwireNetwork.getTile(6, 6, 0).camoDurability, 100,
+        "remote reports must not burn down camouflage")
 end)
 
 test("wire with camo (durability=100, degrade=15): durability reduced to 85, no WireCamouflaged", function()

--- a/tests/test_wire_network.lua
+++ b/tests/test_wire_network.lua
@@ -294,9 +294,13 @@ end)
 
 suite("DeadwireNetwork cooldown")
 
+-- Cooldowns are measured in REAL seconds (os.time), not game hours -- see #16.
+-- These tests drive _setOsTime, not _setWorldAge; advancing world age must have
+-- no effect at all on a cooldown.
+
 test("isOnCooldown returns false when no cooldown set", function()
     _reset()
-    _setWorldAge(0)
+    _setOsTime(0)
     DeadwireNetwork.registerTile(1, 1, 0, 1, "tin_can_tripline", "p1")
     assert_false(DeadwireNetwork.isOnCooldown(1, 1, 0))
 end)
@@ -308,35 +312,52 @@ end)
 
 test("setCooldown then isOnCooldown returns true within window", function()
     _reset()
-    _setWorldAge(10)
+    _setOsTime(1000)
     DeadwireNetwork.registerTile(1, 1, 0, 1, "tin_can_tripline", "p1")
-    DeadwireNetwork.setCooldown(1, 1, 0, 2)   -- expires at hour 12
-    -- Still at hour 10, inside cooldown window
+    DeadwireNetwork.setCooldown(1, 1, 0, 36)   -- expires at t=1036
+    _setOsTime(1035)
     assert_true(DeadwireNetwork.isOnCooldown(1, 1, 0))
 end)
 
 test("isOnCooldown returns false after time advances past cooldown", function()
     _reset()
-    _setWorldAge(10)
+    _setOsTime(1000)
     DeadwireNetwork.registerTile(1, 1, 0, 1, "tin_can_tripline", "p1")
-    DeadwireNetwork.setCooldown(1, 1, 0, 2)   -- expires at hour 12
-    _setWorldAge(13)                            -- advance past cooldown
+    DeadwireNetwork.setCooldown(1, 1, 0, 36)   -- expires at t=1036
+    _setOsTime(1100)
     assert_false(DeadwireNetwork.isOnCooldown(1, 1, 0))
 end)
 
 test("isOnCooldown returns false exactly at expiry boundary", function()
     _reset()
-    _setWorldAge(10)
+    _setOsTime(1000)
     DeadwireNetwork.registerTile(1, 1, 0, 1, "tin_can_tripline", "p1")
-    DeadwireNetwork.setCooldown(1, 1, 0, 2)   -- cooldownUntil = 12
-    _setWorldAge(12)                            -- exactly at boundary: 12 < 12 is false
+    DeadwireNetwork.setCooldown(1, 1, 0, 36)   -- cooldownUntil = 1036
+    _setOsTime(1036)                            -- 1036 < 1036 is false
     assert_false(DeadwireNetwork.isOnCooldown(1, 1, 0))
 end)
 
-test("setCooldown on nonexistent tile is a no-op", function()
+test("cooldown ignores game time entirely (regression: #16)", function()
     _reset()
-    -- Should not throw
-    DeadwireNetwork.setCooldown(99, 99, 99, 5)
+    _setOsTime(1000)
+    _setWorldAge(10)
+    DeadwireNetwork.registerTile(1, 1, 0, 1, "reinforced_tripline", "p1")
+    DeadwireNetwork.setCooldown(1, 1, 0, 36)
+    _setWorldAge(9999)   -- centuries of game time, no real seconds elapsed
+    assert_true(DeadwireNetwork.isOnCooldown(1, 1, 0),
+        "world age must not expire a real-time cooldown")
+end)
+
+test("setCooldown returns the duration applied", function()
+    _reset()
+    _setOsTime(500)
+    DeadwireNetwork.registerTile(1, 1, 0, 1, "reinforced_tripline", "p1")
+    assert_eq(DeadwireNetwork.setCooldown(1, 1, 0, 36), 36)
+end)
+
+test("setCooldown on nonexistent tile is a no-op returning nil", function()
+    _reset()
+    assert_eq(DeadwireNetwork.setCooldown(99, 99, 99, 5), nil)
 end)
 
 


### PR DESCRIPTION
Closes #14, #15, #16, #17, #18.

## Approach

Built `scripts/verify_names.py` + `scripts/pzclass.py` **before** touching any bug.

Session 16 verified names by hand, documented the technique in `context.md`, and committed no tool. The very next name written by hand — `ChurchMisc` → `ChurchStorageMisc` — was also wrong and was committed described as *"verified against vanilla ProceduralDistributions.lua on 42.20"*. A checked claim that leaves no artifact decays into an unchecked one.

The script resolves all 67 game names the mod references against the installed 42.20 and exits non-zero on any that do not. It found two bugs that were not on any issue.

```
python scripts/verify_names.py
verify_names: 67 references checked against ProjectZomboid
All names resolve.
```

## Fixed

| Issue | What was actually wrong |
|---|---|
| #17 | `Perks.Foraging` is nil, so `getPerkLevel` returned 0 for everyone and camouflaged wires were invisible to every player, permanently |
| #18 | No part of `Climate.GetInstance():getRainStrength()` exists. Both guards failed silently, the function always returned 0, camouflage never degraded from weather |
| #14 | `Capability.CanBuildAnywhere` does not exist — and there were **three** call sites, not the one the issue named. `getRole()` also threw in SP |
| #15 | `WireTriggered` accepted any client's claim for any coordinate; `PlaceWire` never checked the player held a kit |
| #16 | Cooldown measured in game time. **Also**: the server set it while detection checks it client-side, so in MP the cooldown never applied at all |

Two of these were bigger than the issue described (#14's three sites, #16's MP path).

## Found by the verifier, not previously filed

- `ChurchStorageMisc` does not exist — 42.20 has no church distribution at all, so bells silently never spawned there. Replaced with `JanitorMisc`.
- Both Tier 1 recipes required `SkillRequired = Carpentry`, which is not a perk. It is `Woodwork`. The recipes were likely uncraftable.

Note `Woodwork` *displays* to players as "Carpentry" and `PlantScavenging` as "Foraging", so the existing Sandbox_EN tooltips are correct and were deliberately left alone.

## Design calls worth a look

- **Cooldown broadcasts a duration, not an absolute time.** `os.time()` is UTC epoch so timezone is not a factor, but server and clients are different machines with independently skewed clocks. Each side adds the duration to its own clock: costs network latency in accuracy, immune to skew.
- **The `WireTriggered` broadcast is no longer gated on `soundName`**, so silent Tanglefoot gets a cooldown too — and the client no longer substitutes `TIN_CAN_RATTLE` when `soundName` is absent, which would have made Tanglefoot audible.
- **A missing loot distribution now logs a warning** instead of being skipped in silence. Every bug that file has had was a nil name with a clean log.
- **Left alone:** Reinforced and Bell still share every stat but sound. Cooldown is the obvious lever to separate them, but that is a balance decision, not a bug fix.

## Testing

131 → 143 tests, all passing. The five new #15 tests were confirmed to **fail** with the guards removed, so they are not vacuous.

**Nothing here has been run against a live game.** Sprites, recipes, loot tables, sounds and the whole camouflage path remain unverified in-game — that is the entire remaining backlog and it is written up in `context.md`.