### PR TITLE
Raise versionMin to 42.15.0 and check tiledef collisions

### DIFF
--- a/.claude/context.md
+++ b/.claude/context.md
@@ -6,7 +6,7 @@ description: PZ mod — perimeter trip lines and electric fencing for Project Zo
 last_session: 17
 last_updated: 2026-08-05
 continue_with: "In-game smoke test: sprites load, recipes registered, loot reachable, sounds play, camo now visible/degrading. All five code bugs (#14-#18) are fixed and merged."
-blockers: "World sprite ART is placeholder. The deadwire_01 tilesheet ships, is declared in mod.info, and its 8 tile indices now provably match the names Config.Sprites asks for (verify_names.py checks this), so the sprites should load and the construction_01_24 fallback should never fire. The 8 images themselves are still Session 10 placeholders, not the finished Gemini art, and nothing has been confirmed rendering in-game."
+blockers: "World sprite ART is placeholder — the 8 images in deadwire_01 are Session 10 placeholders, not finished art. Loading is no longer the suspected problem: validate_pack.py passes 108/108, the 8 tile names match what Config.Sprites asks for, and tiledef id 200 collides with nothing (vanilla is all below 100; no installed mod declares one). That is still an inference from file structure, not an observation of PZ registering the sheet."
 
 tech:
   stack: pz-lua-mod

--- a/Contents/mods/Deadwire/42/mod.info
+++ b/Contents/mods/Deadwire/42/mod.info
@@ -4,6 +4,6 @@ description=Perimeter trip lines and electric fencing for base defense. Tin cans
 url=https://github.com/robannable/deadwire
 poster=42/poster.png
 modversion=0.1.1
-versionMin=42.0.0
+versionMin=42.15.0
 pack=deadwire_01
 tiledef=deadwire_01 200

--- a/Contents/mods/Deadwire/mod.info
+++ b/Contents/mods/Deadwire/mod.info
@@ -4,6 +4,6 @@ description=Perimeter trip lines and electric fencing for base defense. Tin cans
 url=https://github.com/robannable/deadwire
 poster=42/poster.png
 modversion=0.1.1
-versionMin=42.0.0
+versionMin=42.15.0
 pack=deadwire_01
 tiledef=deadwire_01 200

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -54,7 +54,22 @@ Closed in Session 17: #14, #15, #16, #17, #18.
 
 - **v0.1.1** — tagged, released on GitHub. Not on Steam Workshop.
 - mod.info: `modversion=0.1.1`, `pack=deadwire_01`, `tiledef=deadwire_01 200`
-- `versionMin=42.0.0` is **wrong** and should be raised. The mod needs 42.13+ for namespaced tags and 42.15+ for JSON translations.
+- `versionMin` raised `42.0.0` → **`42.15.0`** in Session 17. 42.15 is the floor the mod
+  demonstrably cannot go below (JSON translations landed there; namespaced tags need
+  42.13). It is not a tested claim — everything has only ever been checked against
+  42.20 — but 42.20 would lock out users the mod very likely works for, and 42.0.0 was
+  simply false. Lower it only with evidence, raise it if 42.15 turns out to break.
+
+### Tilesheet: loads-or-not is now answered as far as static checking can
+
+- `python tools/validate_pack.py` → **108/108 pass**. The shipped `.pack` is structurally
+  valid, all 8 sprite names are present at the correct 64×128 regions in a 512×128 sheet,
+  and the header/page/entry layout matches vanilla `Tiles2x.pack`.
+- `tiledef` id 200 is free: vanilla sits entirely below 100 (ids 1, 13, 68, 88) and none
+  of the 6 installed mods declares a tiledef. `verify_names.py` now checks this.
+- So the remaining sprite risk is **art quality, not loading** — with the caveat that
+  "should load" is still an inference from file structure, not an observation of PZ
+  registering the sheet. Confirm with `getSprite("deadwire_01_0")` in the live game.
 
 ---
 

--- a/scripts/verify_names.py
+++ b/scripts/verify_names.py
@@ -20,6 +20,7 @@ Checked categories (each has hard ground truth in the install):
   SkillRequired/xpAward  perk names inside craftRecipe blocks
   Icon = X             media/textures/Item_X.png must exist
   sprite names         this mod's own .tiles.txt tile indices
+  tiledef id           in range, and not colliding with a vanilla tilesheet
 
 Deliberately NOT checked: bare global function names. Many legitimate globals
 are defined in vanilla Lua rather than exposed from Java, so a Java-only check
@@ -27,6 +28,7 @@ reports false positives, and a checker that cries wolf stops being read.
 """
 
 import argparse
+import glob
 import os
 import re
 import sys
@@ -38,6 +40,10 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 MOD = os.path.join(REPO, "Contents", "mods", "Deadwire", "42", "media")
 
 DEFAULT_PZ = r"C:/Program Files (x86)/Steam/steamapps/common/ProjectZomboid"
+
+# Where PZ loads local (non-Workshop) mods from. Used only for tiledef collision
+# checking, and skipped without complaint if it is not there.
+MODS_DIR = os.path.join(os.path.expanduser("~"), "Zomboid", "mods")
 
 # Item ids referenced with a module prefix this checker cannot resolve are
 # skipped rather than reported; only Base.* has a single unambiguous source.
@@ -224,19 +230,20 @@ def check_config_sprites(rep):
         rep.ok("tilesheet", "deadwire_01.pack")
 
 
-def check_modinfo(rep):
-    """Both mod.info files must agree; B42 reads 42/ but the root one is required."""
-    def parse(path):
-        d = {}
-        with open(path, encoding="utf-8", errors="replace") as fh:
-            for line in fh:
-                if "=" in line and not line.strip().startswith("#"):
-                    k, v = line.split("=", 1)
-                    d[k.strip()] = v.strip()
-        return d
+def _parse_modinfo(path):
+    d = {}
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            if "=" in line and not line.strip().startswith("#"):
+                k, v = line.split("=", 1)
+                d[k.strip()] = v.strip()
+    return d
 
-    root = parse(os.path.join(REPO, "Contents", "mods", "Deadwire", "mod.info"))
-    inner = parse(os.path.join(REPO, "Contents", "mods", "Deadwire", "42", "mod.info"))
+
+def check_modinfo(rep, pz):
+    """Both mod.info files must agree; B42 reads 42/ but the root one is required."""
+    root = _parse_modinfo(os.path.join(REPO, "Contents", "mods", "Deadwire", "mod.info"))
+    inner = _parse_modinfo(os.path.join(REPO, "Contents", "mods", "Deadwire", "42", "mod.info"))
     for key in ("name", "id", "modversion", "versionMin", "poster", "pack", "tiledef"):
         a, b = root.get(key), inner.get(key)
         if a == b:
@@ -244,6 +251,44 @@ def check_modinfo(rep):
         else:
             rep.bad("mod.info", key, "Contents/mods/Deadwire/mod.info",
                     "root=%r vs 42/=%r" % (a, b))
+
+    # A tiledef ID collision silently breaks every world sprite: the later
+    # tilesheet wins and Deadwire's tiles resolve to someone else's art.
+    tiledef = inner.get("tiledef", "")
+    parts = tiledef.split()
+    if len(parts) != 2 or not parts[1].isdigit():
+        rep.bad("tiledef", tiledef or "(missing)", "42/mod.info",
+                "expected '<name> <id>' with a numeric id")
+        return
+    ours = int(parts[1])
+    if not 100 <= ours <= 8190:
+        rep.bad("tiledef", str(ours), "42/mod.info", "id must be in 100-8190")
+        return
+
+    # Vanilla currently sits entirely below 100, so in practice the collision
+    # that can actually happen is with another installed mod. Both are checked.
+    taken = {}
+    for tiles_txt in glob.glob(os.path.join(pz, "media", "*.tiles.txt")):
+        with open(tiles_txt, encoding="utf-8", errors="replace") as fh:
+            m = re.search(r"^\s*id\s*=\s*(\d+)", fh.read(), re.M)
+        if m:
+            taken.setdefault(int(m.group(1)), "vanilla " + os.path.basename(tiles_txt))
+
+    for mod_info in glob.glob(os.path.join(MODS_DIR, "*", "mod.info")):
+        other = _parse_modinfo(mod_info)
+        if other.get("id") == "Deadwire":
+            continue
+        bits = other.get("tiledef", "").split()
+        if len(bits) == 2 and bits[1].isdigit():
+            taken.setdefault(int(bits[1]),
+                             "mod " + (other.get("id") or os.path.basename(mod_info)))
+
+    if ours in taken:
+        rep.bad("tiledef", str(ours), "42/mod.info",
+                "collides with %s -- every Deadwire world sprite would resolve "
+                "to the other sheet's art" % taken[ours])
+    else:
+        rep.ok("tiledef", str(ours))
 
 
 def main():
@@ -265,7 +310,7 @@ def main():
     check_lua(rep, jar, items, dists)
     check_scripts(rep, jar, items)
     check_config_sprites(rep)
-    check_modinfo(rep)
+    check_modinfo(rep, args.pz)
 
     print("verify_names: %d references checked against %s"
           % (rep.checked, os.path.basename(args.pz)))


### PR DESCRIPTION
Follow-up to #19. Two things that were known-wrong or unchecked and did not need a running game.

## `versionMin=42.0.0` was false

The mod uses JSON translations (42.15+) and namespaced tags (42.13+). HANDOFF.md has flagged this since Session 16. Raised to **42.15.0**.

Chose 42.15.0 over 42.20.0 deliberately: everything has only ever been checked against 42.20, so 42.15 is not a *tested* claim — but 42.20 would lock out users the mod very likely works for, and 42.0.0 was simply untrue. 42.15 is the floor it demonstrably cannot go below. Lower it only with evidence; raise it if 42.15 turns out to break.

## tiledef validation

`verify_names.py` now checks that `tiledef` parses as `<name> <id>`, that the id is in the legal 100–8190 range, and that it collides with neither a vanilla tilesheet nor another installed mod.

Worth catching because it fails the same silent way as everything else in this project: on a collision the other sheet wins and every Deadwire world sprite resolves to its art, with no error anywhere.

The vanilla half of that check **cannot currently fire** — vanilla ids are 1, 13, 68 and 88, all below the legal mod range — which is why it also scans `~/Zomboid/mods`, where a real collision would actually come from. Both paths were confirmed to fire by forcing a clash rather than assumed to work.

Current state: id 200 is free across vanilla and all 6 installed mods.

## Tilesheet status recorded

`tools/validate_pack.py` passes **108/108** on the shipped `.pack`: all 8 sprites present at the correct 64×128 regions in a 512×128 sheet, header/page/entry layout matching vanilla `Tiles2x.pack`.

That moves the sprite blocker from "might not load" to "art is placeholder" — with the caveat, recorded in both HANDOFF and context, that this is an inference from file structure and **not** an observation of PZ registering the sheet. `getSprite("deadwire_01_0")` in a live game is still the real test.

143 tests passing, 68 name references resolving.