### PR TITLE
Wire up four sandbox options that did nothing

### DIFF
--- a/Contents/mods/Deadwire/42/media/lua/client/Deadwire/Detection.lua
+++ b/Contents/mods/Deadwire/42/media/lua/client/Deadwire/Detection.lua
@@ -61,6 +61,21 @@ local function detectEntity(entity, isZombie)
         if username and wire.ownerId == username then return end
     end
 
+    -- Player-only: faction immunity. FriendlyFireWires defaults to true, meaning
+    -- a faction mate's wire DOES trigger; turning it off makes the perimeter safe
+    -- for the group. The option shipped in sandbox-options.txt and was read by
+    -- nothing at all until now, so it was a settings-screen knob that did nothing.
+    --
+    -- isInSameFaction(IsoPlayer, String) is the overload that matters: the wire
+    -- stores its owner as a username, and that owner may be offline with no
+    -- IsoPlayer to compare against.
+    if not isZombie and not DeadwireConfig.getSandbox("FriendlyFireWires", true) then
+        if wire.ownerId and Faction.isInSameFaction(entity, wire.ownerId) then
+            DeadwireConfig.debugLog("Faction mate passed wire at " .. x .. "," .. y)
+            return
+        end
+    end
+
     -- De-duplicate: prevent same entity from firing multiple triggers
     -- within the same tick cycle (MP latency means cooldown may not be
     -- set on client yet). Uses timestamp with 1-second expiry window.

--- a/Contents/mods/Deadwire/42/media/lua/server/Deadwire/ServerCommands.lua
+++ b/Contents/mods/Deadwire/42/media/lua/server/Deadwire/ServerCommands.lua
@@ -222,7 +222,7 @@ handlers["WireTriggered"] = function(player, args)
 
     -- State changes based on wire type
     local cooldownSeconds = nil
-    if defaults.breakOnTrigger then
+    if DeadwireConfig.breaksOnTrigger(wireType) then
         -- Single-use: destroy wire
         DeadwireWireManager.destroyWire(args.x, args.y, args.z)
         sendServerCommand(DeadwireConfig.MODULE, "WireDestroyed", {

--- a/Contents/mods/Deadwire/42/media/lua/server/Deadwire/WireManager.lua
+++ b/Contents/mods/Deadwire/42/media/lua/server/Deadwire/WireManager.lua
@@ -47,10 +47,11 @@ function DeadwireWireManager.createWire(sq, wireType, ownerId, networkId, north)
 
     -- Create IsoThumpable in the world
     local sprite = getSprite(wireType, north or false)
+    local health = DeadwireConfig.getWireHealth(wireType)
     local obj = IsoThumpable.new(getWorld():getCell(), sq, sprite, north or false, nil)
     obj:setName("DeadwireTripLine")
-    obj:setMaxHealth(defaults.health or 50)
-    obj:setHealth(defaults.health or 50)
+    obj:setMaxHealth(health)
+    obj:setHealth(health)
     obj:setCanPassThrough(true)
     obj:setBlockAllTheSquare(false)
     obj:setIsThumpable(false)

--- a/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/Config.lua
+++ b/Contents/mods/Deadwire/42/media/lua/shared/Deadwire/Config.lua
@@ -123,6 +123,39 @@ function DeadwireConfig.getSandbox(key, default)
     return default
 end
 
+-- Per-type property overrides.
+--
+-- WireDefaults has always been commented "(overridden by SandboxVars)" but
+-- nothing ever read these three options, so the server settings screen offered
+-- players three knobs that did nothing at all. Each option's declared default
+-- in sandbox-options.txt already matches the WireDefaults value it shadows.
+--
+-- Bell deliberately has no health option: the tooltip for ReinforcedHealth says
+-- "reinforced trip lines", and inventing a second meaning for it would be worse
+-- than the gap. Bell keeps the WireDefaults value.
+
+local healthOptions = {
+    tin_can_tripline    = "TripLineHealth",
+    reinforced_tripline = "ReinforcedHealth",
+}
+
+function DeadwireConfig.getWireHealth(wireType)
+    local defaults = DeadwireConfig.WireDefaults[wireType]
+    local fallback = (defaults and defaults.health) or 50
+    local key = healthOptions[wireType]
+    if not key then return fallback end
+    return DeadwireConfig.getSandbox(key, fallback)
+end
+
+function DeadwireConfig.breaksOnTrigger(wireType)
+    local defaults = DeadwireConfig.WireDefaults[wireType]
+    local fallback = (defaults and defaults.breakOnTrigger) or false
+    if wireType == DeadwireConfig.WireTypes.TIN_CAN then
+        return DeadwireConfig.getSandbox("TinCanBreakOnTrigger", fallback)
+    end
+    return fallback
+end
+
 -- Check if a tier is enabled
 function DeadwireConfig.isTierEnabled(tier)
     if not DeadwireConfig.getSandbox("EnableMod", true) then

--- a/scripts/verify_names.py
+++ b/scripts/verify_names.py
@@ -21,6 +21,8 @@ Checked categories (each has hard ground truth in the install):
   Icon = X             media/textures/Item_X.png must exist
   sprite names         this mod's own .tiles.txt tile indices
   tiledef id           in range, and not colliding with a vanilla tilesheet
+  sandbox options      every option declared is read, every key read is declared,
+                       and every declared option has an EN label
 
 Deliberately NOT checked: bare global function names. Many legitimate globals
 are defined in vanilla Lua rather than exposed from Java, so a Java-only check
@@ -29,6 +31,7 @@ reports false positives, and a checker that cries wolf stops being read.
 
 import argparse
 import glob
+import json
 import os
 import re
 import sys
@@ -215,6 +218,75 @@ def check_scripts(rep, jar, items):
                         "expected media/textures/Item_%s.png" % name)
 
 
+# Options whose key is built at runtime rather than written as a literal, so the
+# literal scan below cannot see them. Each must be justified by a real call site.
+DYNAMIC_SANDBOX_KEYS = {
+    "EnableTier0": "Config.isTierEnabled builds the key from the tier number",
+    "EnableTier1": "Config.isTierEnabled",
+    "EnableTier2": "Config.isTierEnabled",
+    "EnableTier3": "Config.isTierEnabled",
+    "EnableTier4": "Config.isTierEnabled",
+    "WireAffectsZombies": "Detection.detectEntity picks the key by entity type",
+    "WireAffectsPlayers": "Detection.detectEntity",
+    "TripLineHealth": "Config.getWireHealth looks it up via healthOptions",
+    "ReinforcedHealth": "Config.getWireHealth via healthOptions",
+}
+
+# Read by Lua and deliberately NOT declared, with a reason. isTierEnabled asks
+# about tiers 2-4, which are Phases 2-4 and have no wire types yet; getSandbox
+# returns the `true` default, which gates nothing because those tiers are empty.
+# Declaring them now would put knobs for absent features on the settings screen.
+# Each must gain a real option as its phase lands.
+UNDECLARED_BY_DESIGN = {
+    "EnableTier2": "Phase 2 (pull-alarms) not implemented",
+    "EnableTier3": "Phase 3 (electric fencing) not implemented, Issue #13",
+    "EnableTier4": "Phase 4 (advanced) not implemented",
+}
+
+
+def check_sandbox_options(rep):
+    """Every option offered to players must be read, and vice versa.
+
+    A key the Lua reads but sandbox-options.txt does not declare is stuck on its
+    hardcoded default forever. A key declared but never read is a knob on the
+    server settings screen that silently does nothing -- which is what
+    TinCanBreakOnTrigger, TripLineHealth and ReinforcedHealth were until
+    Session 17.
+    """
+    used = set()
+    for path in lua_files():
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            code = re.sub(r"--[^\n]*", "", fh.read())
+        used |= set(re.findall(r'getSandbox\(\s*"([A-Za-z0-9_]+)"', code))
+    used |= set(DYNAMIC_SANDBOX_KEYS)
+
+    opts_path = os.path.join(MOD, "sandbox-options.txt")
+    with open(opts_path, encoding="utf-8", errors="replace") as fh:
+        declared = set(re.findall(r"^\s*option\s+Deadwire\.([A-Za-z0-9_]+)",
+                                  fh.read(), re.M))
+
+    for key in sorted(used - declared - set(UNDECLARED_BY_DESIGN)):
+        rep.bad("sandbox option", key, "sandbox-options.txt",
+                "read by Lua but not declared -- permanently stuck on its default")
+    for key in sorted(declared - used):
+        rep.bad("sandbox option", key, "sandbox-options.txt",
+                "declared but never read -- a knob that does nothing")
+    for key in sorted(used & declared):
+        rep.ok("sandbox option", key)
+
+    # Every declared option needs an EN label or the settings screen shows the key.
+    tr_path = os.path.join(MOD, "lua", "shared", "Translate", "EN", "Sandbox_EN.json")
+    with open(tr_path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    table = data.get("Sandbox_EN", data)
+    translated = {k[len("Sandbox_Deadwire_"):] for k in table
+                  if k.startswith("Sandbox_Deadwire_")
+                  and not k.endswith("_tooltip") and "_option" not in k}
+    for key in sorted(declared - translated):
+        rep.bad("sandbox translation", key, "Translate/EN/Sandbox_EN.json",
+                "declared option has no EN label")
+
+
 def check_config_sprites(rep):
     """Config.Sprites must name tiles the shipped tilesheet defines."""
     sprites = mod_sprites()
@@ -309,6 +381,7 @@ def main():
     rep = Report()
     check_lua(rep, jar, items, dists)
     check_scripts(rep, jar, items)
+    check_sandbox_options(rep)
     check_config_sprites(rep)
     check_modinfo(rep, args.pz)
 

--- a/tests/stubs.lua
+++ b/tests/stubs.lua
@@ -147,6 +147,24 @@ os.time = function() return _osTime end
 function _setOsTime(t) _osTime = t end   -- test control
 
 -----------------------------------------------------------------
+-- Faction stub (Detection.lua faction immunity)
+-- Real signature: Faction.isInSameFaction(IsoPlayer, String) -> boolean.
+-- Tests declare membership by username via _setFaction.
+-----------------------------------------------------------------
+local _factions = {}   -- username -> faction name
+
+Faction = {
+    isInSameFaction = function(player, ownerUsername)
+        if not player or not ownerUsername then return false end
+        local mine = _factions[player:getUsername()]
+        return mine ~= nil and mine == _factions[ownerUsername]
+    end,
+}
+
+function _setFaction(username, factionName) _factions[username] = factionName end
+function _clearFactions() _factions = {} end
+
+-----------------------------------------------------------------
 -- PZ capability system stub
 -- UseBuildCheat is the real 42.20 name. CanBuildAnywhere, which this stub
 -- used to declare, does not exist in the game -- so the stub was validating
@@ -275,6 +293,7 @@ function _reset()
     _sentServer = {}
     _sentClient = {}
     _soundCalls = {}
+    _factions = {}
     SandboxVars = { Deadwire = {} }
     -- Reset WireNetwork internal state (if loaded)
     if DeadwireNetwork then DeadwireNetwork.clear() end

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -280,3 +280,80 @@ test("debugLog handles non-string argument without throwing", function()
     DeadwireConfig.debugLog(true)
     DeadwireConfig.DEBUG = prev
 end)
+
+
+-----------------------------------------------------------------
+-- Per-type SandboxVars overrides
+--
+-- These three options existed in sandbox-options.txt and were shown to players
+-- on the server settings screen, but nothing in the mod ever read them, so
+-- setting them did nothing. Regression tests for that.
+-----------------------------------------------------------------
+
+suite("DeadwireConfig.getWireHealth")
+
+test("falls back to WireDefaults when the option is unset", function()
+    _reset()
+    assert_eq(DeadwireConfig.getWireHealth("tin_can_tripline"),
+        DeadwireConfig.WireDefaults.tin_can_tripline.health)
+    assert_eq(DeadwireConfig.getWireHealth("reinforced_tripline"),
+        DeadwireConfig.WireDefaults.reinforced_tripline.health)
+end)
+
+test("TripLineHealth overrides tin can health", function()
+    _reset()
+    SandboxVars.Deadwire.TripLineHealth = 400
+    assert_eq(DeadwireConfig.getWireHealth("tin_can_tripline"), 400)
+end)
+
+test("ReinforcedHealth overrides reinforced health", function()
+    _reset()
+    SandboxVars.Deadwire.ReinforcedHealth = 900
+    assert_eq(DeadwireConfig.getWireHealth("reinforced_tripline"), 900)
+end)
+
+test("the two health options do not bleed into each other", function()
+    _reset()
+    SandboxVars.Deadwire.TripLineHealth = 400
+    SandboxVars.Deadwire.ReinforcedHealth = 900
+    assert_eq(DeadwireConfig.getWireHealth("tin_can_tripline"), 400)
+    assert_eq(DeadwireConfig.getWireHealth("reinforced_tripline"), 900)
+end)
+
+test("bell is unaffected by ReinforcedHealth (no option of its own)", function()
+    _reset()
+    SandboxVars.Deadwire.ReinforcedHealth = 900
+    assert_eq(DeadwireConfig.getWireHealth("bell_tripline"),
+        DeadwireConfig.WireDefaults.bell_tripline.health)
+end)
+
+test("unknown wire type returns the 50 fallback without throwing", function()
+    _reset()
+    assert_eq(DeadwireConfig.getWireHealth("definitely_not_a_wire"), 50)
+end)
+
+
+suite("DeadwireConfig.breaksOnTrigger")
+
+test("tin can breaks by default", function()
+    _reset()
+    assert_true(DeadwireConfig.breaksOnTrigger("tin_can_tripline"))
+end)
+
+test("TinCanBreakOnTrigger=false makes tin can reusable", function()
+    _reset()
+    SandboxVars.Deadwire.TinCanBreakOnTrigger = false
+    assert_false(DeadwireConfig.breaksOnTrigger("tin_can_tripline"))
+end)
+
+test("reusable wires are unaffected by TinCanBreakOnTrigger", function()
+    _reset()
+    SandboxVars.Deadwire.TinCanBreakOnTrigger = true
+    assert_false(DeadwireConfig.breaksOnTrigger("reinforced_tripline"))
+    assert_false(DeadwireConfig.breaksOnTrigger("bell_tripline"))
+end)
+
+test("unknown wire type does not break and does not throw", function()
+    _reset()
+    assert_false(DeadwireConfig.breaksOnTrigger("definitely_not_a_wire"))
+end)

--- a/tests/test_detection.lua
+++ b/tests/test_detection.lua
@@ -335,3 +335,95 @@ test("WireOwnerImmunity = true, player is NOT owner, trigger fires", function()
 
     DeadwireDetection.playerHandlers["tin_can_tripline"] = nil
 end)
+
+
+-----------------------------------------------------------------
+-- Faction immunity (FriendlyFireWires)
+--
+-- The option shipped in sandbox-options.txt from the start and was read by
+-- nothing at all, so it was a knob on the server settings screen that did
+-- nothing. Default true = a faction mate's wire still triggers.
+-----------------------------------------------------------------
+
+suite("Detection: FriendlyFireWires")
+
+local function withPlayerHandler(wireType, fn)
+    local called = false
+    DeadwireDetection.playerHandlers[wireType] = function() called = true end
+    fn()
+    DeadwireDetection.playerHandlers[wireType] = nil
+    return called
+end
+
+test("default (true): faction mate still triggers the wire", function()
+    _reset()
+    _makeSquare(4, 4, 0)
+    DeadwireNetwork.registerTile(4, 4, 0, 1, "tin_can_tripline", "alice")
+    _setFaction("alice", "Rangers")
+    _setFaction("bob", "Rangers")
+
+    local called = withPlayerHandler("tin_can_tripline", function()
+        Events.OnPlayerUpdate:Fire(_mockPlayer(4, 4, 0, "bob"))
+    end)
+
+    assert_true(called, "friendly fire is on by default")
+end)
+
+test("false: faction mate passes safely", function()
+    _reset()
+    _makeSquare(4, 4, 0)
+    DeadwireNetwork.registerTile(4, 4, 0, 1, "tin_can_tripline", "alice")
+    SandboxVars.Deadwire.FriendlyFireWires = false
+    _setFaction("alice", "Rangers")
+    _setFaction("bob", "Rangers")
+
+    local called = withPlayerHandler("tin_can_tripline", function()
+        Events.OnPlayerUpdate:Fire(_mockPlayer(4, 4, 0, "bob"))
+    end)
+
+    assert_false(called, "faction mate should pass a mate's wire safely")
+end)
+
+test("false: a stranger still triggers the wire", function()
+    _reset()
+    _makeSquare(4, 4, 0)
+    DeadwireNetwork.registerTile(4, 4, 0, 1, "tin_can_tripline", "alice")
+    SandboxVars.Deadwire.FriendlyFireWires = false
+    _setFaction("alice", "Rangers")
+    _setFaction("mallory", "Bandits")
+
+    local called = withPlayerHandler("tin_can_tripline", function()
+        Events.OnPlayerUpdate:Fire(_mockPlayer(4, 4, 0, "mallory"))
+    end)
+
+    assert_true(called, "a rival faction must not get immunity")
+end)
+
+test("false: factionless player still triggers the wire", function()
+    _reset()
+    _makeSquare(4, 4, 0)
+    DeadwireNetwork.registerTile(4, 4, 0, 1, "tin_can_tripline", "alice")
+    SandboxVars.Deadwire.FriendlyFireWires = false
+    _setFaction("alice", "Rangers")
+
+    local called = withPlayerHandler("tin_can_tripline", function()
+        Events.OnPlayerUpdate:Fire(_mockPlayer(4, 4, 0, "nobody"))
+    end)
+
+    assert_true(called, "no faction means no immunity")
+end)
+
+test("false: zombies are unaffected by the faction check", function()
+    _reset()
+    _makeSquare(4, 4, 0)
+    DeadwireNetwork.registerTile(4, 4, 0, 1, "tin_can_tripline", "alice")
+    SandboxVars.Deadwire.FriendlyFireWires = false
+    _setFaction("alice", "Rangers")
+
+    local called = false
+    DeadwireDetection.zombieHandlers["tin_can_tripline"] = function() called = true end
+    Events.OnZombieUpdate:Fire(_mockZombie(4, 4, 0, true))
+    DeadwireDetection.zombieHandlers["tin_can_tripline"] = nil
+
+    assert_true(called, "faction immunity is player-only")
+end)

--- a/tests/test_server_commands.lua
+++ b/tests/test_server_commands.lua
@@ -405,6 +405,24 @@ test("reinforced (breakOnTrigger=false): no destroy, cooldown set, WireTriggered
         "broadcast must carry the cooldown duration for clients to mirror")
 end)
 
+test("TinCanBreakOnTrigger=false makes tin can reusable end to end", function()
+    resetAll()
+    SandboxVars.Deadwire.TinCanBreakOnTrigger = false
+    _setOsTime(1000)
+    local sq = _makeSquare(6, 6, 0)
+    DeadwireNetwork.registerTile(6, 6, 0, 1, "tin_can_tripline", "alice")
+
+    local player = _mockPlayer(6, 6, 0, "bob")
+
+    Events.OnClientCommand:Fire("Deadwire", "WireTriggered", player, {
+        x = 6, y = 6, z = 0, wireType = "tin_can_tripline"
+    })
+
+    assert_eq(#_destroyedWires, 0, "tin can should survive when the option is off")
+    assert_true(DeadwireNetwork.isOnCooldown(6, 6, 0),
+        "a now-reusable tin can must get a cooldown instead")
+end)
+
 -- #15: detection is necessarily client-side, so the server cannot verify that
 -- a wire fired -- only that the reporter is close enough to have seen it.
 


### PR DESCRIPTION
Follow-up to #19 and #20.

## The problem

The server settings screen offered **four knobs that no code read**. Setting them had no effect, and there was no way for a player to tell.

Found by a new cross-check in `verify_names.py`: every option declared in `sandbox-options.txt` must be read by the Lua, every key the Lua reads must be declared, and every declared option must have an EN label. Same silent-failure shape as the name bugs — the UI promises something the code never consults.

## Fixed

| Option | Now does |
|---|---|
| `TripLineHealth` | drives tin can `IsoThumpable` health via `Config.getWireHealth` |
| `ReinforcedHealth` | drives reinforced wire health |
| `TinCanBreakOnTrigger` | turning it off really does make tin cans reusable — they fall through to the cooldown path |
| `FriendlyFireWires` | faction mates get immunity in `Detection` |

Both health defaults already matched the `WireDefaults` values they shadow, and `WireDefaults` has always carried the comment *"(overridden by SandboxVars)"* — so this was intent that was never implemented, not a new feature.

**Bell deliberately gets no health option.** The `ReinforcedHealth` tooltip says "reinforced trip lines"; giving it a second meaning is worse than the gap.

`FriendlyFireWires` uses `Faction.isInSameFaction(IsoPlayer, String)`. The `String` overload is the one that matters: a wire stores its owner as a username, and that owner may be offline with no `IsoPlayer` to compare against. Signature read off the jar, not assumed.

## Deliberate exemption

`EnableTier2/3/4` are read by `isTierEnabled` but **not** declared, because tiers 2–4 have no wire types yet and declaring them would put knobs for absent features on the settings screen. Recorded in the checker as an explicit exemption with a reason each, rather than silently ignored — each must gain a real option as its phase lands.

## Testing

143 → 159 tests, all passing. 100 references resolving. The faction guard was confirmed to **fail** its tests when removed.

Still nothing verified against a live game.